### PR TITLE
fix: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 dist
 node_modules
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 node_modules
 .env
+.env.*


### PR DESCRIPTION
This pull request adds .env to the .gitignore file to prevent sensitive environment variables from being accidentally committed to the repository.

Discussed in issue: https://github.com/vercel/v0-sdk/issues/1