### PR TITLE
feat: Add comprehensive .env rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 .DS_Store
 dist
 node_modules
+
+# Env variables
+.env
+.env.production
+.env.development
+.env.test
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
## Description

This pull request enhances repository security by adding a comprehensive set of `.env` file patterns to the `.gitignore` file. 
Fix  #1 

## Why is this change necessary?

Environment files (`.env.*`) often contain sensitive information such as API keys, database credentials, and other secrets. Accidentally committing these files to version control poses a significant security risk.

This change ensures that environment files for development, testing, and production are all properly ignored by Git, safeguarding secrets across all stages of the development lifecycle.

## Changes

- Added a new section `# Env variables` for clarity.
- Added the following patterns to [.gitignore](cci:7://file:///d:/vercel/v0-sdk/.gitignore:0:0-0:0):
  - `.env`
  - `.env.production`
  - `.env.development`
  - `.env.test`
  - `.env.local`
  - `.env.development.local`
  - `.env.test.local`
  - `.env.production.local`
  
