### PR TITLE
make v0-clone the recommended example for create-v0-sdk-app

### DIFF
--- a/.changeset/ripe-fans-add.md
+++ b/.changeset/ripe-fans-add.md
@@ -1,0 +1,5 @@
+---
+'create-v0-sdk-app': patch
+---
+
+make v0-clone the recommended example

--- a/packages/create-v0-sdk-app/LICENSE
+++ b/packages/create-v0-sdk-app/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2025 Vercel, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/create-v0-sdk-app/README.md
+++ b/packages/create-v0-sdk-app/README.md
@@ -1,18 +1,18 @@
 # create-v0-sdk-app
 
-Create v0 SDK-powered apps with one command.
+Create [v0 SDK](https://v0-sdk.dev)-powered apps with one command.
 
 ## Usage
 
 ```bash
-npx create-v0-sdk-app my-app
+pnpm create v0-sdk-app my-app
 ```
 
 Or with other package managers:
 
 ```bash
-# With pnpm
-pnpm create v0-sdk-app my-app
+# With npm
+npx create-v0-sdk-app my-app
 
 # With yarn
 yarn create v0-sdk-app my-app
@@ -24,36 +24,28 @@ bun create v0-sdk-app my-app
 ## Options
 
 - `--example <example-name>` - Specify which example to use
+- `--use-pnpm` - Use pnpm as the package manager (recommended)
 - `--use-npm` - Use npm as the package manager
-- `--use-pnpm` - Use pnpm as the package manager
 - `--use-yarn` - Use Yarn as the package manager
 - `--use-bun` - Use Bun as the package manager
 - `--skip-install` - Skip installing dependencies
 
 ## Available Examples
 
-### ai-tools-example
+### v0-clone (Recommended)
 
-Node.js example using `@v0-sdk/ai-tools` with AI SDK. Perfect for building AI-powered command-line tools and scripts.
+Next.js app that replicates the v0.dev interface with modern React components and AI chat functionality. This is the recommended starting point for most projects.
 
 ```bash
-npx create-v0-sdk-app my-ai-app --example ai-tools-example
+pnpm create v0-sdk-app my-app --example v0-clone
 ```
 
 ### classic-v0
 
-Full-featured Next.js app similar to v0.dev with project management, chat interface, and code generation capabilities.
+Full-featured Next.js app similar to the original v0.dev with project management, chat interface, and code generation capabilities.
 
 ```bash
-npx create-v0-sdk-app my-classic-app --example classic-v0
-```
-
-### v0-clone
-
-Next.js app that replicates the v0.dev interface with modern React components and AI chat functionality.
-
-```bash
-npx create-v0-sdk-app my-clone-app --example v0-clone
+pnpm create v0-sdk-app my-classic-app --example classic-v0
 ```
 
 ### v0-sdk-react-example
@@ -61,7 +53,15 @@ npx create-v0-sdk-app my-clone-app --example v0-clone
 Next.js example using `@v0-sdk/react` components with different UI themes (minimal, elegant, neobrutalism, terminal).
 
 ```bash
-npx create-v0-sdk-app my-react-app --example v0-sdk-react-example
+pnpm create v0-sdk-app my-react-app --example v0-sdk-react-example
+```
+
+### ai-tools-example
+
+Node.js example using `@v0-sdk/ai-tools` with AI SDK. Perfect for building AI-powered command-line tools and scripts.
+
+```bash
+pnpm create v0-sdk-app my-ai-app --example ai-tools-example
 ```
 
 ## Interactive Mode
@@ -69,12 +69,12 @@ npx create-v0-sdk-app my-react-app --example v0-sdk-react-example
 If you don't specify an example, the CLI will prompt you to choose one:
 
 ```bash
-npx create-v0-sdk-app my-app
+pnpm create v0-sdk-app my-app
 # ? Which example would you like to use? (Use arrow keys)
-# ❯ ai-tools-example - Node.js example using @v0-sdk/ai-tools with AI SDK
-#   classic-v0 - Full-featured Next.js app similar to v0.dev
-#   v0-clone - Next.js app that replicates the v0.dev interface
+# ❯ v0-clone - Next.js app that replicates the v0.dev interface (Recommended)
+#   classic-v0 - Full-featured Next.js app similar to the original v0.dev
 #   v0-sdk-react-example - Next.js example using @v0-sdk/react components
+#   ai-tools-example - Node.js example using @v0-sdk/ai-tools with AI SDK
 ```
 
 ## What's Included
@@ -104,4 +104,4 @@ pnpm dev --help
 
 ## License
 
-MIT
+Apache 2.0

--- a/packages/create-v0-sdk-app/package.json
+++ b/packages/create-v0-sdk-app/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/create-v0-sdk-app"
   },
   "author": "Vercel Team <support@vercel.com>",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bin": {
     "create-v0-sdk-app": "./dist/index.js"
   },

--- a/packages/create-v0-sdk-app/src/index.ts
+++ b/packages/create-v0-sdk-app/src/index.ts
@@ -37,7 +37,8 @@ const onPromptState = (state: {
 const examples: { name: ExampleType; description: string }[] = [
   {
     name: 'v0-clone',
-    description: 'Next.js app that replicates the v0.dev interface (Recommended)',
+    description:
+      'Next.js app that replicates the v0.dev interface (Recommended)',
   },
   {
     name: 'classic-v0',

--- a/packages/create-v0-sdk-app/src/index.ts
+++ b/packages/create-v0-sdk-app/src/index.ts
@@ -36,9 +36,8 @@ const onPromptState = (state: {
 
 const examples: { name: ExampleType; description: string }[] = [
   {
-    name: 'ai-tools-example',
-    description:
-      'Node.js example using @v0-sdk/ai-tools with AI SDK + AI Gateway',
+    name: 'v0-clone',
+    description: 'Next.js app that replicates the v0.dev interface (Recommended)',
   },
   {
     name: 'classic-v0',
@@ -46,12 +45,13 @@ const examples: { name: ExampleType; description: string }[] = [
       'Full-featured Next.js app similar to the original v0.dev released in 2023',
   },
   {
-    name: 'v0-clone',
-    description: 'Next.js app that replicates the v0.dev interface',
-  },
-  {
     name: 'v0-sdk-react-example',
     description: 'Next.js example using @v0-sdk/react components',
+  },
+  {
+    name: 'ai-tools-example',
+    description:
+      'Node.js example using @v0-sdk/ai-tools with AI SDK + AI Gateway',
   },
 ]
 
@@ -73,12 +73,12 @@ const program = new Command(packageJson.name)
 `,
   )
   .option(
-    '--use-npm',
-    'Explicitly tell the CLI to bootstrap the application using npm.',
+    '--use-pnpm',
+    'Explicitly tell the CLI to bootstrap the application using pnpm (recommended).',
   )
   .option(
-    '--use-pnpm',
-    'Explicitly tell the CLI to bootstrap the application using pnpm.',
+    '--use-npm',
+    'Explicitly tell the CLI to bootstrap the application using npm.',
   )
   .option(
     '--use-yarn',
@@ -102,10 +102,10 @@ const program = new Command(packageJson.name)
 
 const opts = program.opts()
 
-const packageManager: PackageManager = !!opts.useNpm
-  ? 'npm'
-  : !!opts.usePnpm
-    ? 'pnpm'
+const packageManager: PackageManager = !!opts.usePnpm
+  ? 'pnpm'
+  : !!opts.useNpm
+    ? 'npm'
     : !!opts.useYarn
       ? 'yarn'
       : !!opts.useBun


### PR DESCRIPTION
This changes uses `v0-clone` as default for `pnpm create v0-sdk-app`