### PR TITLE
chore(docs-update-attachmens-url-info): impl

### DIFF
--- a/packages/v0-sdk/openapi.json
+++ b/packages/v0-sdk/openapi.json
@@ -45,7 +45,8 @@
                       "type": "object",
                       "properties": {
                         "url": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The URL or data URI of the file or asset to include with the message."
                         }
                       },
                       "required": ["url"],
@@ -1660,7 +1661,8 @@
                       "type": "object",
                       "properties": {
                         "url": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The URL or data URI of the file or asset to include with the message."
                         }
                       },
                       "required": ["url"],


### PR DESCRIPTION
Hi,

Attachments for Chats support data URIs, too. It would be awesome to attach this info to the docs for end users.

Best,