### PR TITLE
add createdAt, userId to usage report

### DIFF
--- a/.changeset/nine-adults-watch.md
+++ b/.changeset/nine-adults-watch.md
@@ -1,0 +1,5 @@
+---
+'v0-sdk': patch
+---
+
+add createdAt, userId to usage report

--- a/packages/v0-sdk/openapi.json
+++ b/packages/v0-sdk/openapi.json
@@ -6810,7 +6810,7 @@
     "/reports/usage": {
       "get": {
         "summary": "Get Usage Report",
-        "description": "Retrieves detailed usage events for the authenticated user or team, including costs, event types, models used, and metadata. Shows the same data as displayed in the usage dashboard. Can be filtered by chatId to show usage for a specific chat.",
+        "description": "Retrieves detailed usage events for the authenticated user or team, including costs, event types, models used, and metadata. Shows the same data as displayed in the usage dashboard. Can be filtered by chatId to show usage for a specific chat, or by userId to show usage for a specific user.",
         "operationId": "reports.getUsage",
         "tags": ["reports"],
         "responses": {
@@ -6868,9 +6868,15 @@
                           },
                           "user": {
                             "$ref": "#/components/schemas/UserSummarySchema"
+                          },
+                          "createdAt": {
+                            "description": "The ISO timestamp representing when the usage event was created.",
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
                           }
                         },
-                        "required": ["id", "object", "totalCost"],
+                        "required": ["id", "object", "totalCost", "createdAt"],
                         "additionalProperties": false
                       }
                     },
@@ -7028,6 +7034,15 @@
               "type": "string"
             },
             "description": "Query parameter \"messageId\""
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Query parameter \"userId\""
           },
           {
             "name": "limit",

--- a/packages/v0-sdk/src/sdk/v0.ts
+++ b/packages/v0-sdk/src/sdk/v0.ts
@@ -1174,6 +1174,7 @@ export type ReportsGetUsageResponse = {
     messageId?: string
     userId?: string
     user?: UserSummarySchema
+    createdAt: string
   }>
   pagination: {
     hasMore: boolean
@@ -1824,6 +1825,7 @@ export function createClient(config: V0ClientConfig = {}) {
         endDate?: string
         chatId?: string
         messageId?: string
+        userId?: string
         limit?: number
         cursor?: string
       }): Promise<ReportsGetUsageResponse> {
@@ -1834,6 +1836,7 @@ export function createClient(config: V0ClientConfig = {}) {
                 endDate: params.endDate,
                 chatId: params.chatId,
                 messageId: params.messageId,
+                userId: params.userId,
                 limit:
                   params.limit !== undefined ? String(params.limit) : undefined,
                 cursor: params.cursor,


### PR DESCRIPTION
This change adds `createAt` and `userId` to Usage Report API: https://v0.app/docs/api/platform/reference/reports/get-usage