### PR TITLE
feat: add optional headers parameter to v0 SDK

### DIFF
--- a/packages/v0-sdk/src/sdk/core.ts
+++ b/packages/v0-sdk/src/sdk/core.ts
@@ -1,6 +1,7 @@
 export interface ClientConfig {
   apiKey?: string
   baseUrl?: string
+  headers?: Record<string, string>
 }
 
 export function createFetcher(config: ClientConfig = {}) {
@@ -35,6 +36,7 @@ export function createFetcher(config: ClientConfig = {}) {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${apiKey}`,
       'User-Agent': 'v0-sdk/0.1.0',
+      ...config.headers,
       ...params.headers,
     }
 
@@ -163,6 +165,7 @@ export function createStreamingFetcher(config: ClientConfig = {}) {
       'User-Agent': 'v0-sdk/0.1.0',
       Accept: 'text/event-stream',
       'Cache-Control': 'no-cache',
+      ...config.headers,
       ...params.headers,
     }
 

--- a/packages/v0-sdk/src/sdk/v0.ts
+++ b/packages/v0-sdk/src/sdk/v0.ts
@@ -1211,6 +1211,7 @@ export type ReportsGetUsageResponse = {
 export interface V0ClientConfig {
   apiKey?: string
   baseUrl?: string
+  headers?: Record<string, string>
 }
 
 export function createClient(config: V0ClientConfig = {}) {


### PR DESCRIPTION
This PR introduces an optional `headers` parameter to the v0 SDK, enabling more flexible request customization.

**Problem/Issue/Goal:**
- The v0 SDK lacked a mechanism to include custom HTTP headers in requests.
- Users needed the ability to pass specific headers for various use cases (e.g., authentication, custom metadata).

**Fix/Solution:**
- Extended `ClientConfig` and `V0ClientConfig` to include an optional `headers` parameter.
- This allows developers to define and send custom headers with requests made via the v0 SDK.

Chat link: https://v0.app/chat/33LFeJPhvrO