### PR TITLE
Fix rendering of hr elements

### DIFF
--- a/.changeset/plenty-crabs-press.md
+++ b/.changeset/plenty-crabs-press.md
@@ -1,5 +1,5 @@
 ---
-"@v0-sdk/react": patch
+'@v0-sdk/react': patch
 ---
 
 Fix void element rendering error for elements like `hr` that have no children

--- a/.changeset/plenty-crabs-press.md
+++ b/.changeset/plenty-crabs-press.md
@@ -1,0 +1,5 @@
+---
+"@v0-sdk/react": patch
+---
+
+Fix void element rendering error for elements like `hr` that have no children

--- a/packages/react/src/components/message.ts
+++ b/packages/react/src/components/message.ts
@@ -247,11 +247,14 @@ function MessageRenderer({
             props?.className,
             componentOrConfig.className,
           )
-          return React.createElement(
-            tagName,
-            { key: element.key, ...props, className: mergedClassName },
-            renderedChildren,
-          )
+          const elementProps = {
+            key: element.key,
+            ...props,
+            className: mergedClassName,
+          }
+          return renderedChildren?.length
+            ? React.createElement(tagName, elementProps, renderedChildren)
+            : React.createElement(tagName, elementProps)
         } else {
           // Default HTML element rendering
           const elementProps: Record<string, any> = {
@@ -268,7 +271,9 @@ function MessageRenderer({
             elementProps.rel = 'noopener noreferrer'
           }
 
-          return React.createElement(tagName, elementProps, renderedChildren)
+          return renderedChildren?.length
+            ? React.createElement(tagName, elementProps, renderedChildren)
+            : React.createElement(tagName, elementProps)
         }
 
       case 'component':


### PR DESCRIPTION
There's a bug where if the response contains a `["hr"]` element, the code throws with:

```
hr is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
```

This fixes it by making sure we don't render `[]` children if there isn't any