### PR TITLE
test: add missing tests for mcpServers and reports + fix chats/create body assertion

### DIFF
--- a/packages/v0-sdk/tests/chats/create.test.ts
+++ b/packages/v0-sdk/tests/chats/create.test.ts
@@ -26,7 +26,7 @@ describe('v0.chats.create', () => {
       url: 'https://v0.dev/chat/chat-123',
       text: 'Hello, world!',
       modelConfiguration: {
-        modelId: 'v0-1.5-md',
+        modelId: 'v0-auto',
       },
     }
 
@@ -44,6 +44,10 @@ describe('v0.chats.create', () => {
         chatPrivacy: undefined,
         projectId: undefined,
         modelConfiguration: undefined,
+        responseMode: undefined,
+        designSystemId: undefined,
+        mcpServerIds: undefined,
+        metadata: undefined,
       },
     })
 
@@ -64,7 +68,7 @@ describe('v0.chats.create', () => {
         chatId: 'test',
         url: 'test',
         text: 'test',
-        modelConfiguration: { modelId: 'v0-1.5-md' },
+        modelConfiguration: { modelId: 'v0-auto' },
       })
 
       await v0.chats.create({
@@ -81,7 +85,13 @@ describe('v0.chats.create', () => {
   })
 
   it('should handle different model configurations', async () => {
-    const modelIds = ['v0-1.5-sm', 'v0-1.5-md', 'v0-1.5-lg'] as const
+    const modelIds = [
+      'v0-auto',
+      'v0-mini',
+      'v0-pro',
+      'v0-max',
+      'v0-max-fast',
+    ] as const
 
     for (const modelId of modelIds) {
       mockFetcher.mockResolvedValue({
@@ -115,7 +125,7 @@ describe('v0.chats.create', () => {
       chatId: 'test',
       url: 'test',
       text: 'test',
-      modelConfiguration: { modelId: 'v0-1.5-md' },
+      modelConfiguration: { modelId: 'v0-auto' },
     })
 
     await v0.chats.create({

--- a/packages/v0-sdk/tests/mcpServers/create.test.ts
+++ b/packages/v0-sdk/tests/mcpServers/create.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.mcpServers.create', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should create an MCP server with minimal parameters', async () => {
+    const mockResponse = {
+      object: 'mcp_server',
+      id: 'mcp-123',
+      name: 'My Server',
+      url: 'https://mcp.example.com',
+      enabled: true,
+      auth: { type: 'none' },
+      scope: 'user',
+      createdAt: '2024-01-01T00:00:00Z',
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.mcpServers.create({
+      name: 'My Server',
+      url: 'https://mcp.example.com',
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers', 'POST', {
+      body: {
+        name: 'My Server',
+        url: 'https://mcp.example.com',
+        description: undefined,
+        enabled: undefined,
+        auth: undefined,
+        scope: undefined,
+      },
+    })
+
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should create an MCP server with bearer auth', async () => {
+    const mockResponse = {
+      object: 'mcp_server',
+      id: 'mcp-456',
+      name: 'Secure Server',
+      url: 'https://mcp.example.com',
+      enabled: true,
+      auth: { type: 'bearer' },
+      scope: 'user',
+      createdAt: '2024-01-01T00:00:00Z',
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    await v0.mcpServers.create({
+      name: 'Secure Server',
+      url: 'https://mcp.example.com',
+      auth: { type: 'bearer', token: 'my-secret-token' },
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers', 'POST', {
+      body: expect.objectContaining({
+        auth: { type: 'bearer', token: 'my-secret-token' },
+      }),
+    })
+  })
+
+  it('should create a team-scoped MCP server', async () => {
+    mockFetcher.mockResolvedValue({
+      object: 'mcp_server',
+      id: 'mcp-789',
+      name: 'Team Server',
+      url: 'https://mcp.example.com',
+      enabled: true,
+      auth: { type: 'none' },
+      scope: 'team',
+      createdAt: '2024-01-01T00:00:00Z',
+    })
+
+    await v0.mcpServers.create({
+      name: 'Team Server',
+      url: 'https://mcp.example.com',
+      scope: 'team',
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers', 'POST', {
+      body: expect.objectContaining({ scope: 'team' }),
+    })
+  })
+
+  it('should handle API errors', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 422: Unprocessable Entity'))
+
+    await expect(
+      v0.mcpServers.create({ name: 'Bad Server', url: 'not-a-valid-url' }),
+    ).rejects.toThrow('HTTP 422: Unprocessable Entity')
+  })
+})

--- a/packages/v0-sdk/tests/mcpServers/delete.test.ts
+++ b/packages/v0-sdk/tests/mcpServers/delete.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.mcpServers.delete', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should delete an MCP server by ID', async () => {
+    const mockResponse = {
+      object: 'mcp_server',
+      id: 'mcp-123',
+      deleted: true,
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.mcpServers.delete({ mcpServerId: 'mcp-123' })
+
+    expect(mockFetcher).toHaveBeenCalledWith(
+      '/mcp-servers/mcp-123',
+      'DELETE',
+      { pathParams: { mcpServerId: 'mcp-123' } },
+    )
+
+    expect(result).toEqual(mockResponse)
+    expect(result.deleted).toBe(true)
+  })
+
+  it('should throw for a non-existent server', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 404: Not Found'))
+
+    await expect(
+      v0.mcpServers.delete({ mcpServerId: 'does-not-exist' }),
+    ).rejects.toThrow('HTTP 404: Not Found')
+  })
+})

--- a/packages/v0-sdk/tests/mcpServers/find.test.ts
+++ b/packages/v0-sdk/tests/mcpServers/find.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.mcpServers.find', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should return a list of MCP servers', async () => {
+    const mockResponse = {
+      object: 'list',
+      data: [
+        {
+          object: 'mcp_server',
+          id: 'mcp-123',
+          name: 'My MCP Server',
+          url: 'https://mcp.example.com',
+          description: 'A test MCP server',
+          enabled: true,
+          auth: { type: 'none' },
+          scope: 'user',
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      ],
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.mcpServers.find()
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers', 'GET', {})
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should return an empty list when no servers exist', async () => {
+    const mockResponse = { object: 'list', data: [] }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.mcpServers.find()
+
+    expect(result.data).toHaveLength(0)
+  })
+
+  it('should handle API errors', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 401: Unauthorized'))
+
+    await expect(v0.mcpServers.find()).rejects.toThrow('HTTP 401: Unauthorized')
+  })
+})

--- a/packages/v0-sdk/tests/mcpServers/get-by-id.test.ts
+++ b/packages/v0-sdk/tests/mcpServers/get-by-id.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.mcpServers.getById', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should get an MCP server by ID', async () => {
+    const mockResponse = {
+      object: 'mcp_server',
+      id: 'mcp-123',
+      name: 'My Server',
+      url: 'https://mcp.example.com',
+      enabled: true,
+      auth: { type: 'none' },
+      scope: 'user',
+      createdAt: '2024-01-01T00:00:00Z',
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.mcpServers.getById({ mcpServerId: 'mcp-123' })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers/mcp-123', 'GET', {
+      pathParams: { mcpServerId: 'mcp-123' },
+    })
+
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should throw for a non-existent server', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 404: Not Found'))
+
+    await expect(
+      v0.mcpServers.getById({ mcpServerId: 'does-not-exist' }),
+    ).rejects.toThrow('HTTP 404: Not Found')
+  })
+})

--- a/packages/v0-sdk/tests/mcpServers/update.test.ts
+++ b/packages/v0-sdk/tests/mcpServers/update.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.mcpServers.update', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should update an MCP server name', async () => {
+    const mockResponse = {
+      object: 'mcp_server',
+      id: 'mcp-123',
+      name: 'Updated Name',
+      url: 'https://mcp.example.com',
+      enabled: true,
+      auth: { type: 'none' },
+      scope: 'user',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-06-01T00:00:00Z',
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.mcpServers.update({
+      mcpServerId: 'mcp-123',
+      name: 'Updated Name',
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers/mcp-123', 'PATCH', {
+      pathParams: { mcpServerId: 'mcp-123' },
+      body: {
+        name: 'Updated Name',
+        url: undefined,
+        description: undefined,
+        enabled: undefined,
+        auth: undefined,
+        scope: undefined,
+      },
+    })
+
+    expect(result.name).toBe('Updated Name')
+  })
+
+  it('should disable an MCP server', async () => {
+    mockFetcher.mockResolvedValue({
+      object: 'mcp_server',
+      id: 'mcp-123',
+      name: 'My Server',
+      url: 'https://mcp.example.com',
+      enabled: false,
+      auth: { type: 'none' },
+      scope: 'user',
+      createdAt: '2024-01-01T00:00:00Z',
+    })
+
+    await v0.mcpServers.update({ mcpServerId: 'mcp-123', enabled: false })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/mcp-servers/mcp-123', 'PATCH', {
+      pathParams: { mcpServerId: 'mcp-123' },
+      body: expect.objectContaining({ enabled: false }),
+    })
+  })
+
+  it('should handle API errors', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 404: Not Found'))
+
+    await expect(
+      v0.mcpServers.update({ mcpServerId: 'nonexistent', name: 'Foo' }),
+    ).rejects.toThrow('HTTP 404: Not Found')
+  })
+})

--- a/packages/v0-sdk/tests/reports/get-usage.test.ts
+++ b/packages/v0-sdk/tests/reports/get-usage.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.reports.getUsage', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should fetch usage with no filters', async () => {
+    const mockResponse = {
+      object: 'list',
+      data: [],
+      pagination: { hasMore: false },
+      meta: { totalCount: 0 },
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.reports.getUsage()
+
+    expect(mockFetcher).toHaveBeenCalledWith('/reports/usage', 'GET', {})
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should pass date range filters as query params', async () => {
+    mockFetcher.mockResolvedValue({
+      object: 'list',
+      data: [],
+      pagination: { hasMore: false },
+      meta: { totalCount: 0 },
+    })
+
+    await v0.reports.getUsage({
+      startDate: '2024-01-01',
+      endDate: '2024-01-31',
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/reports/usage', 'GET', {
+      query: { startDate: '2024-01-01', endDate: '2024-01-31' },
+    })
+  })
+
+  it('should pass chatId and messageId filters', async () => {
+    mockFetcher.mockResolvedValue({
+      object: 'list',
+      data: [],
+      pagination: { hasMore: false },
+      meta: { totalCount: 0 },
+    })
+
+    await v0.reports.getUsage({ chatId: 'chat-abc', messageId: 'msg-xyz' })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/reports/usage', 'GET', {
+      query: { chatId: 'chat-abc', messageId: 'msg-xyz' },
+    })
+  })
+
+  it('should convert numeric limit to string in query params', async () => {
+    mockFetcher.mockResolvedValue({
+      object: 'list',
+      data: [],
+      pagination: { hasMore: false },
+      meta: { totalCount: 0 },
+    })
+
+    await v0.reports.getUsage({ limit: 50 })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/reports/usage', 'GET', {
+      query: { limit: '50' },
+    })
+  })
+
+  it('should handle paginated results', async () => {
+    const mockResponse = {
+      object: 'list',
+      data: [
+        {
+          id: 'event-1',
+          object: 'usage_event',
+          type: 'message',
+          totalCost: '0.05',
+          createdAt: '2024-01-15T10:00:00Z',
+        },
+      ],
+      pagination: { hasMore: true, nextCursor: 'cursor-abc' },
+      meta: { totalCount: 100 },
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.reports.getUsage({ cursor: 'cursor-abc' })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/reports/usage', 'GET', {
+      query: { cursor: 'cursor-abc' },
+    })
+    expect(result.pagination.hasMore).toBe(true)
+  })
+
+  it('should handle API errors', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 403: Forbidden'))
+
+    await expect(v0.reports.getUsage()).rejects.toThrow('HTTP 403: Forbidden')
+  })
+})

--- a/packages/v0-sdk/tests/reports/get-user-activity.test.ts
+++ b/packages/v0-sdk/tests/reports/get-user-activity.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createClient } from '../../src/sdk/v0'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.reports.getUserActivity', () => {
+  let v0: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+    v0 = createClient()
+  })
+
+  it('should fetch user activity with no filters', async () => {
+    const mockResponse = {
+      object: 'list',
+      data: [],
+      meta: {
+        totalCount: 0,
+        dateRange: { start: '2024-01-01', end: '2024-01-31' },
+      },
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.reports.getUserActivity()
+
+    expect(mockFetcher).toHaveBeenCalledWith(
+      '/reports/user-activity',
+      'GET',
+      {},
+    )
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should pass date range query params', async () => {
+    mockFetcher.mockResolvedValue({
+      object: 'list',
+      data: [],
+      meta: { totalCount: 0, dateRange: {} },
+    })
+
+    await v0.reports.getUserActivity({
+      startDate: '2024-03-01',
+      endDate: '2024-03-31',
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith(
+      '/reports/user-activity',
+      'GET',
+      { query: { startDate: '2024-03-01', endDate: '2024-03-31' } },
+    )
+  })
+
+  it('should return user activity data with correct shape', async () => {
+    const mockResponse = {
+      object: 'list',
+      data: [
+        {
+          id: 'activity-1',
+          object: 'user_activity',
+          user: {
+            id: 'user-abc',
+            object: 'user',
+            email: 'dev@example.com',
+            avatar: 'https://example.com/avatar.png',
+            createdAt: '2024-01-01T00:00:00Z',
+            teamV0Role: 'V0Builder',
+          },
+          chatCount: 42,
+          messageCount: 300,
+          activeDays: 20,
+          firstActivity: '2024-03-01T00:00:00Z',
+          lastActivity: '2024-03-31T00:00:00Z',
+        },
+      ],
+      meta: {
+        totalCount: 1,
+        dateRange: { start: '2024-03-01', end: '2024-03-31' },
+      },
+    }
+
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const result = await v0.reports.getUserActivity()
+
+    expect(result.data[0].chatCount).toBe(42)
+    expect(result.data[0].user.email).toBe('dev@example.com')
+    expect(result.meta.totalCount).toBe(1)
+  })
+
+  it('should handle API errors', async () => {
+    mockFetcher.mockRejectedValue(new Error('HTTP 403: Forbidden'))
+
+    await expect(v0.reports.getUserActivity()).rejects.toThrow(
+      'HTTP 403: Forbidden',
+    )
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds missing test coverage for `mcpServers` and `reports` namespaces 
which were fully implemented in the SDK but had zero tests. 
Also fixes an incomplete assertion in the existing `chats/create` test.

## New Files Added

- `tests/mcpServers/find.test.ts`
- `tests/mcpServers/create.test.ts`
- `tests/mcpServers/get-by-id.test.ts`
- `tests/mcpServers/update.test.ts`
- `tests/mcpServers/delete.test.ts`
- `tests/reports/get-usage.test.ts`
- `tests/reports/get-user-activity.test.ts`

## Bug Fix

`tests/chats/create.test.ts` — assertion was missing `responseMode`, 
`designSystemId`, `mcpServerIds` and `metadata` fields that the 
implementation already sends. Fixed to match the actual request body.

## Test Results

All tests pass with no errors:

- Test Files: 39 passed
- Tests: 192 passed