### PR TITLE
ci: set explicit read permissions on verify-changesets workflow

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - '.changeset/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   verify-changesets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I work on software supply chain security and have been hardening GitHub Actions workflows across OSS projects.

Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes. This PR sets `permissions: contents: read` at the workflow level for `.github/workflows/verify-changesets.yml`, which is all these jobs need (checkout plus the build/test steps). Scoping the token to read-only shrinks what a compromised step or dependency can do, a concern made concrete by the March 2025 `tj-actions/changed-files` compromise (CVE-2025-30066), where a leaked write-scoped `GITHUB_TOKEN` was the blast radius.

No job behavior changes; the steps already only read the repository.