### PR TITLE
Install packages from npm in examples

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+link-workspace-packages=true
+prefer-workspace-packages=true

--- a/examples/ai-tools-example/package.json
+++ b/examples/ai-tools-example/package.json
@@ -14,7 +14,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@v0-sdk/ai-tools": "workspace:*",
+    "@v0-sdk/ai-tools": "^0.3.8",
     "ai": "^5.0.22",
     "dotenv": "^16.4.5",
     "zod": "^3.25.76"

--- a/examples/classic-v0/package.json
+++ b/examples/classic-v0/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.5",
     "react-syntax-highlighter": "^15.6.6",
     "tailwind-merge": "^2.5.5",
-    "v0-sdk": "workspace:*"
+    "v0-sdk": "^0.16.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/examples/simple-v0/package.json
+++ b/examples/simple-v0/package.json
@@ -28,7 +28,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "tailwind-merge": "^3.3.1",
-    "v0-sdk": "workspace:*",
+    "v0-sdk": "^0.16.4",
     "vaul": "^1.1.2"
   },
   "devDependencies": {

--- a/examples/v0-clone/package.json
+++ b/examples/v0-clone/package.json
@@ -23,7 +23,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
-    "@v0-sdk/react": "workspace:*",
+    "@v0-sdk/react": "^0.5.0",
     "@vercel/postgres": "^0.10.0",
     "ai": "^5.0.22",
     "bcrypt-ts": "^7.1.0",
@@ -47,7 +47,7 @@
     "tailwind-merge": "^2.5.5",
     "tsx": "^4.19.2",
     "use-stick-to-bottom": "^1.1.1",
-    "v0-sdk": "workspace:*",
+    "v0-sdk": "^0.16.4",
     "zod": "^4.1.1"
   },
   "devDependencies": {

--- a/examples/v0-sdk-react-example/package.json
+++ b/examples/v0-sdk-react-example/package.json
@@ -14,7 +14,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
-    "@v0-sdk/react": "workspace:*",
+    "@v0-sdk/react": "^0.5.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "katex": "^0.16.8",

--- a/packages/create-v0-sdk-app/src/create-app.ts
+++ b/packages/create-v0-sdk-app/src/create-app.ts
@@ -77,9 +77,9 @@ export async function createApp({
         if (version === 'workspace:*') {
           // Map workspace packages to their published versions
           const packageVersions: Record<string, string> = {
-            'v0-sdk': '^0.11.0',
-            '@v0-sdk/react': '^0.3.0',
-            '@v0-sdk/ai-tools': '^0.1.0',
+            'v0-sdk': '^0.16.4',
+            '@v0-sdk/react': '^0.5.0',
+            '@v0-sdk/ai-tools': '^0.3.8',
           }
 
           if (packageVersions[name]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
   examples/ai-tools-example:
     dependencies:
       '@v0-sdk/ai-tools':
-        specifier: workspace:*
+        specifier: ^0.3.8
         version: link:../../packages/ai-tools
       ai:
         specifier: ^5.0.22
@@ -186,7 +186,7 @@ importers:
         specifier: ^2.5.5
         version: 2.6.1
       v0-sdk:
-        specifier: workspace:*
+        specifier: ^0.16.4
         version: link:../../packages/v0-sdk
     devDependencies:
       '@tailwindcss/postcss':
@@ -268,7 +268,7 @@ importers:
         specifier: ^3.3.1
         version: 3.5.0
       v0-sdk:
-        specifier: workspace:*
+        specifier: ^0.16.4
         version: link:../../packages/v0-sdk
       vaul:
         specifier: ^1.1.2
@@ -335,7 +335,7 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.2.14)(react@19.2.5)
       '@v0-sdk/react':
-        specifier: workspace:*
+        specifier: ^0.5.0
         version: link:../../packages/react
       '@vercel/postgres':
         specifier: ^0.10.0
@@ -407,7 +407,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.4(react@19.2.5)
       v0-sdk:
-        specifier: workspace:*
+        specifier: ^0.16.4
         version: link:../../packages/v0-sdk
       zod:
         specifier: ^4.1.1
@@ -450,7 +450,7 @@ importers:
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@v0-sdk/react':
-        specifier: workspace:*
+        specifier: ^0.5.0
         version: link:../../packages/react
       class-variance-authority:
         specifier: ^0.7.0


### PR DESCRIPTION
Fixes #81. Examples now work as standalone projects, so you can install and deploy them without the rest of the workspace present.