### PR TITLE
Add preview proxy helper

### DIFF
--- a/packages/v0-sdk/src/index.ts
+++ b/packages/v0-sdk/src/index.ts
@@ -4,7 +4,9 @@ import type { Auth, AuthToken } from './generated/core/auth.gen'
 import { createV0StreamResult, type V0StreamResult } from './stream/result'
 import { vercelOidcAuth } from './vercel-oidc'
 
+export { fetchPreview } from './preview-proxy'
 export * from './stream'
+export type { FetchPreviewOptions } from './preview-proxy'
 export { vercelOidcAuth, type VercelOidcAuthOptions } from './vercel-oidc'
 export type * from './generated/types.gen'
 

--- a/packages/v0-sdk/src/preview-proxy.ts
+++ b/packages/v0-sdk/src/preview-proxy.ts
@@ -93,12 +93,19 @@ export async function fetchPreview({
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers: getPreviewResponseHeaders(response),
   })
 }
 
 function redirectToFallback(request: Request, fallbackUrl: string | URL) {
   return Response.redirect(new URL(fallbackUrl, request.url), 302)
+}
+
+function getPreviewResponseHeaders(response: Response) {
+  const headers = new Headers(response.headers)
+  headers.delete('content-encoding')
+  headers.delete('content-length')
+  return headers
 }
 
 function normalizePreviewPath(path: string | string[]) {

--- a/packages/v0-sdk/src/preview-proxy.ts
+++ b/packages/v0-sdk/src/preview-proxy.ts
@@ -1,0 +1,110 @@
+import type { ChatsGetPreviewResponse } from './generated'
+
+/**
+ * Options for `fetchPreview`.
+ */
+export type FetchPreviewOptions = {
+  /**
+   * Request received by your proxy route. The helper preserves the method,
+   * headers, body, and query string when forwarding to the preview URL.
+   */
+  request: Request
+  /**
+   * Preview returned by `v0.chats.getPreview`, usually from your cache. Pass
+   * `null` when the preview is not ready.
+   */
+  preview: ChatsGetPreviewResponse['preview']
+  /**
+   * URL to redirect the iframe to when the preview is not ready or v0 asks the
+   * proxy to refresh the preview. This should point at a loading route that
+   * retries your proxy route.
+   */
+  fallbackUrl: string | URL
+  /**
+   * Path under the iframe proxy route to forward to the preview URL. In Next.js
+   * catch-all routes, pass the `[[...path]]` param directly.
+   */
+  path?: string | string[]
+  /**
+   * Optional fetch implementation for tests or custom runtimes. Defaults to
+   * `globalThis.fetch`.
+   */
+  fetch?: typeof fetch
+  /**
+   * Called before redirecting to `fallbackUrl` when v0 returns
+   * `x-v0-preview-refresh: 1`. Use this to clear your cached preview.
+   */
+  onPreviewRefresh?: () => void | Promise<void>
+}
+
+const previewRefreshHeader = 'x-v0-preview-refresh'
+const previewTokenHeader = 'x-v0-preview-token'
+
+/**
+ * Handles one request to your preview proxy route.
+ *
+ * Pass the cached preview from `v0.chats.getPreview`. When a preview is
+ * available, this forwards the request to the preview URL with
+ * `x-v0-preview-token` attached. If no preview is available, it redirects the
+ * iframe to `fallbackUrl`.
+ *
+ * If the preview response includes `x-v0-preview-refresh: 1`, this calls
+ * `onPreviewRefresh` so your route can clear its cached preview, then redirects
+ * the iframe to `fallbackUrl`. The helper does not call `v0.chats.getPreview`
+ * or manage your cache.
+ */
+export async function fetchPreview({
+  request,
+  preview,
+  fallbackUrl,
+  path = [],
+  fetch: fetchFn = globalThis.fetch,
+  onPreviewRefresh,
+}: FetchPreviewOptions): Promise<Response> {
+  if (!preview) {
+    return redirectToFallback(request, fallbackUrl)
+  }
+
+  const incomingUrl = new URL(request.url)
+  const baseHeaders = new Headers(request.headers)
+  baseHeaders.delete('host')
+
+  const upstreamUrl = new URL(normalizePreviewPath(path), preview.url)
+  upstreamUrl.search = incomingUrl.search
+
+  const headers = new Headers(baseHeaders)
+  headers.set(previewTokenHeader, preview.token)
+
+  const hasBody = request.method !== 'GET' && request.method !== 'HEAD'
+  const body = hasBody ? await request.arrayBuffer() : undefined
+
+  const response = await fetchFn(upstreamUrl, {
+    method: request.method,
+    headers,
+    body,
+    redirect: 'manual',
+  })
+
+  if (response.headers.get(previewRefreshHeader) === '1') {
+    await onPreviewRefresh?.()
+    return redirectToFallback(request, fallbackUrl)
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}
+
+function redirectToFallback(request: Request, fallbackUrl: string | URL) {
+  return Response.redirect(new URL(fallbackUrl, request.url), 302)
+}
+
+function normalizePreviewPath(path: string | string[]) {
+  if (typeof path === 'string') {
+    return path.startsWith('/') ? path : `/${path}`
+  }
+
+  return `/${path.map((segment) => encodeURIComponent(segment)).join('/')}`
+}


### PR DESCRIPTION
## Summary

Add an SDK helper for forwarding iframe preview proxy requests to v0 preview URLs.

- Exports `fetchPreview` from the SDK package.
- Forwards request method, headers, body, and query string to the preview URL.
- Redirects to a caller-provided fallback URL when the preview is unavailable or v0 asks for a refresh.

## Problem

Customers embedding v0 previews need to proxy iframe traffic so they can attach the preview token header and make sure the sandbox is running. The docs example captures the intended flow, but every caller has to reimplement request forwarding, refresh detection, fallback redirects, and cache invalidation hooks.

## Solution

Introduce `fetchPreview`, which takes the incoming proxy `Request`, the cached `v0.chats.getPreview` result, a fallback URL, and optional path/fetch/refresh callback options. The helper forwards valid preview traffic and redirects to the fallback route when the preview is null or when the upstream response includes `x-v0-preview-refresh: 1`.

Depends on #158 so the helper can type `preview` as `ChatsGetPreviewResponse["preview"]`, including `null`.

## Verification

- `bun --filter v0 typecheck`
- `bun --filter @v0-sdk/ai-tools typecheck`
- `bun --filter @v0-sdk/ai-tools test`
- `bun run fmt:check packages/v0-sdk/openapi.json packages/v0-sdk/src/generated/sdk.gen.ts packages/v0-sdk/src/generated/transformers.gen.ts packages/v0-sdk/src/generated/types.gen.ts packages/v0-sdk/src/preview-proxy.ts packages/v0-sdk/src/index.ts packages/ai-tools/src/scripts/generate.ts packages/ai-tools/src/generated/tools.ts`
- `git diff --check`