### PR TITLE
Add AI SDK compatibility via v0/ai-sdk and v0/react

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,36 @@ for await (const update of result.stream) {
 console.log(await result.final)
 ```
 
+## AI SDK
+
+The `v0/ai-sdk` and `v0/react` entry points adapt v0 chats to the [AI SDK](https://ai-sdk.dev), with `ai`, `@ai-sdk/react`, and `react` as optional peer dependencies.
+
+```ts
+// app/api/chat/route.ts
+import { v0 } from 'v0'
+import { toUIMessageStreamResponse } from 'v0/ai-sdk'
+
+export async function POST(request: Request) {
+  const { chatId, message, attachments } = await request.json()
+
+  return toUIMessageStreamResponse(
+    chatId
+      ? await v0.messages.sendStream({ chatId, message, attachments })
+      : await v0.chats.createStream({ message, attachments }),
+  )
+}
+```
+
+```tsx
+'use client'
+
+import { useV0Chat } from 'v0/react'
+
+const { messages, sendMessage, chatId } = useV0Chat()
+```
+
+Messages are fully typed (`V0UIMessage`), derived from the SDK's `Message` type. `toUIMessages` converts `v0.messages.list` responses into initial `useChat` messages, and `resume: true` reconnects to in-flight generations. See the [package README](./packages/v0-sdk/README.md#ai-sdk) for the full guide.
+
 ## Development
 
 This repo uses Bun workspaces.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "v0-sdk",
@@ -80,23 +81,45 @@
         "@hey-api/client-fetch": "^0.13.1",
         "@vercel/oidc": "^3.5.0",
         "jsondiffpatch": "^0.6.0",
+        "legid": "^0.1.4",
       },
       "devDependencies": {
+        "@ai-sdk/react": "^4.0.16",
         "@arethetypeswrong/core": "^0.18.2",
+        "@happy-dom/global-registrator": "^20.10.6",
         "@hey-api/openapi-ts": "0.94.3",
         "@tsconfig/strictest": "^2.0.8",
+        "@types/bun": "latest",
+        "@types/react": "^19.0.0",
+        "ai": "^7.0.15",
         "publint": "^0.3.18",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "tsdown": "^0.21.4",
         "typescript": "^5.9.3",
       },
+      "peerDependencies": {
+        "@ai-sdk/react": "^4.0.0",
+        "ai": "^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+      },
+      "optionalPeers": [
+        "@ai-sdk/react",
+        "ai",
+        "react",
+      ],
     },
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.105", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.27", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-X0cdnJ/B422AvtKf5C2ZO8cyVf36utX8DORg6AHux1+a3EGYSLIy91L6MrUKOP68c7dL3WnAirOaiQrGL8rueQ=="],
 
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DX1v5M/R4RD2yi1KSH2ERLKcb6h2qJF0DKt0PGTTpNJNK+meXMmouwSRZS8Y+JocbyHk7U9p6PgqVmKU/e5XhQ=="],
+
     "@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.27", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-JFhJK5ynprll2FR3e+sHagJJIwvIagsNA0FLbLPq2Os4yLUK2/eiaCU0jXsADik73/hhvcPPLmD+Uo8eu5kFaQ=="],
+
+    "@ai-sdk/react": ["@ai-sdk/react@4.0.16", "", { "dependencies": { "@ai-sdk/mcp": "2.0.7", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "ai": "7.0.15", "swr": "^2.4.1", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-VpJhn9ob7EC9g2Wn5m/FCCu8h6Uj4tE7u8BunK0kNo5kJasEl/f3oHV7f3r4tNtq4zW5wu0EjGs5sKkShErGew=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -129,6 +152,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
     "@hey-api/client-fetch": ["@hey-api/client-fetch@0.13.1", "", { "peerDependencies": { "@hey-api/openapi-ts": "< 2" } }, "sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA=="],
 
@@ -458,6 +483,10 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@upstash/core-analytics": ["@upstash/core-analytics@0.0.10", "", { "dependencies": { "@upstash/redis": "^1.28.3" } }, "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ=="],
 
     "@upstash/ratelimit": ["@upstash/ratelimit@2.0.8", "", { "dependencies": { "@upstash/core-analytics": "^0.0.10" }, "peerDependencies": { "@upstash/redis": "^1.34.3" } }, "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w=="],
@@ -471,6 +500,8 @@
     "@vercel/cli-exec": ["@vercel/cli-exec@0.1.1", "", { "dependencies": { "execa": "5.1.1" } }, "sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.6.1", "", { "dependencies": { "@vercel/cli-config": "0.2.0", "@vercel/cli-exec": "0.1.1", "jose": "^5.9.6" } }, "sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw=="],
+
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
     "ai": ["ai@5.0.206", "", { "dependencies": { "@ai-sdk/gateway": "2.0.105", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.27", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LQ+Jh0VAXbLhpiLlkAs4WcBUFzh59B5WVb+YgAya15mMUuXeDdeozw2UduM6tKQ+i6uNaSqtV/bJkiG8Ogp6lA=="],
 
@@ -489,6 +520,8 @@
     "basic": ["basic@workspace:examples/basic"],
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -534,6 +567,8 @@
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -549,6 +584,8 @@
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -571,6 +608,8 @@
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
@@ -601,6 +640,8 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "jsondiffpatch": ["jsondiffpatch@0.6.2", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-c4RkbPb6RXWjkhirwcKK87PuZCITdGRN1usrW4pXKEkwp7Gqf+0pSwQHoh/LtlYNHcxzoF6kok2/EFe6KL0qqQ=="],
+
+    "legid": ["legid@0.1.4", "", {}, "sha512-SlKVLZT+D+reRjCyJ6MdPar3qZnyogOl7LjlQ+0NaDTd4hDaKYG2hGjJ7ZT1cOgXB3DAw6Lo7uHoRwbgN1HfsQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -676,6 +717,8 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
@@ -732,11 +775,15 @@
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
+    "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
+
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
@@ -766,13 +813,19 @@
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "v0": ["v0@workspace:packages/v0-sdk"],
 
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
@@ -783,6 +836,16 @@
     "zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
     "@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+
+    "@ai-sdk/mcp/@ai-sdk/provider": ["@ai-sdk/provider@4.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw=="],
+
+    "@ai-sdk/mcp/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A=="],
+
+    "@ai-sdk/react/@ai-sdk/provider": ["@ai-sdk/provider@4.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw=="],
+
+    "@ai-sdk/react/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A=="],
+
+    "@ai-sdk/react/ai": ["ai@7.0.15", "", { "dependencies": { "@ai-sdk/gateway": "4.0.12", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw=="],
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
@@ -814,8 +877,22 @@
 
     "simple-v0/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "v0/ai": ["ai@7.0.15", "", { "dependencies": { "@ai-sdk/gateway": "4.0.12", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw=="],
+
+    "@ai-sdk/react/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA=="],
+
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0" } }, "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw=="],
 
+    "v0/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA=="],
+
+    "v0/ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw=="],
+
+    "v0/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A=="],
+
+    "@ai-sdk/react/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "ast-kit/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0", "", {}, "sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g=="],
+
+    "v0/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
   }
 }

--- a/packages/v0-sdk/README.md
+++ b/packages/v0-sdk/README.md
@@ -24,6 +24,146 @@ if (response.error) {
 console.log(response.data.chat.id)
 ```
 
-The default `v0` client uses `V0_API_KEY` when present, otherwise it falls back to Vercel OIDC auth for server-side code deployed on Vercel. Use `createV0Client` when you need custom auth or client options.
+The default `v0` client uses `V0_API_KEY` when present, otherwise it falls back
+to Vercel OIDC auth for server-side code deployed on Vercel. Use
+`createV0Client` when you need custom auth or client options.
+
+## AI SDK
+
+`v0/ai-sdk` and `v0/react` adapt v0 chats to the [AI SDK](https://ai-sdk.dev) so
+`useChat` works out of the box, including streaming and stream resumption. They
+are opt-in: install the peer dependencies you use.
+
+```sh
+npm install ai          # for v0/ai-sdk
+npm install @ai-sdk/react react  # additionally, for v0/react
+```
+
+Stream v0 responses from a route handler:
+
+```ts
+// app/api/chat/route.ts
+import { v0 } from 'v0'
+import { toUIMessageStreamResponse } from 'v0/ai-sdk'
+
+export async function POST(request: Request) {
+  const { chatId, message, attachments } = await request.json()
+
+  return toUIMessageStreamResponse(
+    chatId
+      ? await v0.messages.sendStream({ chatId, message, attachments })
+      : await v0.chats.createStream({ message, attachments }),
+  )
+}
+
+export async function GET(request: Request) {
+  const chatId = new URL(request.url).searchParams.get('chatId')
+  if (!chatId) return new Response(null, { status: 204 })
+
+  try {
+    return toUIMessageStreamResponse(await v0.chats.resume({ chatId }))
+  } catch {
+    return new Response(null, { status: 204 })
+  }
+}
+```
+
+And consume them with `useV0Chat`, a `useChat` preconfigured for the route
+above:
+
+```tsx
+'use client'
+
+import { useV0Chat } from 'v0/react'
+
+export function Chat() {
+  const { messages, sendMessage, status, chatId } = useV0Chat()
+
+  return (
+    <>
+      {messages.map((message) => (
+        <div key={message.id}>
+          {message.parts.map((part, index) => {
+            switch (part.type) {
+              case 'text':
+                return <p key={index}>{part.text}</p>
+              case 'reasoning':
+                return <em key={index}>{part.text}</em>
+              case 'data-file-edit':
+                return (
+                  <code
+                    key={index}
+                  >{`${part.data.operation} ${part.data.path}`}</code>
+                )
+              default:
+                return null
+            }
+          })}
+        </div>
+      ))}
+      <button
+        disabled={status !== 'ready'}
+        onClick={() => sendMessage({ text: 'Make it pop' })}
+      >
+        Send
+      </button>
+    </>
+  )
+}
+```
+
+Every part, metadata field, and data part is typed, derived from the SDK's
+`Message` type: `text` and `thinking` parts map to the AI SDK's `text` and
+`reasoning` parts, every other v0 part becomes a typed `data-*` part
+(`data-file-edit`, `data-bash`, `data-tool-call`, ...), and the remaining
+`Message` fields (`chatId`, `finishReason`, `usage`, ...) are the message
+metadata.
+
+`useV0Chat` sends `{ chatId, message, attachments }` request bodies, tracks the
+v0 `chatId` from the response metadata for follow-up messages, and passes a
+provided `chatId` through as the `useChat` id. Anything `useChat` accepts
+(callbacks, initial `messages`, `resume`, ...) is accepted too. Prefer the plain
+hook? `useChat<V0UIMessage>()` works with the same route handler.
+
+Load an existing conversation with `toUIMessages`:
+
+```ts
+import { v0 } from 'v0'
+import { toUIMessages } from 'v0/ai-sdk'
+
+const response = await v0.messages.list({ chatId, limit: 100 })
+
+if (response.error) {
+  throw new Error(response.error.message)
+}
+
+const messages = toUIMessages(response.data.messages)
+```
+
+```tsx
+useV0Chat({ chatId, messages })
+```
+
+To resume a generation that is still streaming (for example after a reload, or
+after creating a chat with `v0.chats.createAsync` and redirecting), pass
+`resume: true` together with `chatId`; the hook reconnects through the `GET`
+handler above.
+
+```tsx
+useV0Chat({ chatId, messages, resume: true })
+```
+
+While a response streams, chat snapshots (including the generated title) arrive
+as transient `data-chat` parts:
+
+```tsx
+useV0Chat({
+  onData: (part) => {
+    if (part.type === 'data-chat') {
+      console.log(part.data.title)
+    }
+  },
+})
+```
 
 See https://v0.app/docs/api/v2 for full documentation and API reference.

--- a/packages/v0-sdk/bunfig.toml
+++ b/packages/v0-sdk/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup.ts"]

--- a/packages/v0-sdk/package.json
+++ b/packages/v0-sdk/package.json
@@ -21,30 +21,73 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
+  "typesVersions": {
+    "*": {
+      "ai-sdk": [
+        "./dist/ai-sdk.d.cts"
+      ],
+      "react": [
+        "./dist/react.d.cts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./ai-sdk": {
+      "import": "./dist/ai-sdk.mjs",
+      "require": "./dist/ai-sdk.cjs"
+    },
+    "./react": {
+      "import": "./dist/react.mjs",
+      "require": "./dist/react.cjs"
     },
     "./package.json": "./package.json"
   },
   "scripts": {
     "generate": "openapi-ts",
     "build": "tsdown",
+    "test": "bun test",
     "typecheck": "tsc",
     "prepublishOnly": "bun run generate && bun run build"
   },
   "dependencies": {
     "@hey-api/client-fetch": "^0.13.1",
     "@vercel/oidc": "^3.5.0",
-    "jsondiffpatch": "^0.6.0"
+    "jsondiffpatch": "^0.6.0",
+    "legid": "^0.1.4"
   },
   "devDependencies": {
+    "@ai-sdk/react": "^4.0.16",
     "@arethetypeswrong/core": "^0.18.2",
+    "@happy-dom/global-registrator": "^20.10.6",
     "@hey-api/openapi-ts": "0.94.3",
     "@tsconfig/strictest": "^2.0.8",
+    "@types/bun": "latest",
+    "@types/react": "^19.0.0",
+    "ai": "^7.0.15",
     "publint": "^0.3.18",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tsdown": "^0.21.4",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@ai-sdk/react": "^4.0.0",
+    "ai": "^7.0.0",
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@ai-sdk/react": {
+      "optional": true
+    },
+    "ai": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/v0-sdk/src/ai-sdk/index.ts
+++ b/packages/v0-sdk/src/ai-sdk/index.ts
@@ -6,4 +6,4 @@ export type {
   V0UIMessage,
   V0UIMessageChunk,
 } from './ui-message'
-export { toUIMessageStream, toUIMessageStreamResponse } from './ui-message-stream'
+export { toResumeResponse, toUIMessageStream, toUIMessageStreamResponse } from './ui-message-stream'

--- a/packages/v0-sdk/src/ai-sdk/index.ts
+++ b/packages/v0-sdk/src/ai-sdk/index.ts
@@ -1,0 +1,9 @@
+export { fromUIMessage, toUIMessage, toUIMessages } from './ui-message'
+export type {
+  Serialized,
+  V0DataParts,
+  V0MessageMetadata,
+  V0UIMessage,
+  V0UIMessageChunk,
+} from './ui-message'
+export { toUIMessageStream, toUIMessageStreamResponse } from './ui-message-stream'

--- a/packages/v0-sdk/src/ai-sdk/ui-message-stream.ts
+++ b/packages/v0-sdk/src/ai-sdk/ui-message-stream.ts
@@ -1,0 +1,351 @@
+import { createUIMessageStreamResponse } from 'ai'
+import type { Chat } from '../generated/types.gen'
+import type { V0StreamEvent, V0StreamFinal, V0StreamResult, V0StreamUpdate } from '../stream/result'
+import { serializeDates } from './ui-message'
+import type { Serialized, V0MessageMetadata, V0UIMessageChunk } from './ui-message'
+
+/**
+ * Converts a {@link V0StreamResult} (from `v0.chats.createStream`,
+ * `v0.chats.resume`, `v0.messages.sendStream`, or `v0.messages.resolveStream`)
+ * into an AI SDK UI message stream of {@link V0UIMessageChunk}s.
+ *
+ * Prefer {@link toUIMessageStreamResponse} in route handlers; use this when
+ * you need the raw chunk stream, for example to merge it into a stream created
+ * with `createUIMessageStream` or to read it with `readUIMessageStream`.
+ */
+export function toUIMessageStream(result: V0StreamResult): ReadableStream<V0UIMessageChunk> {
+  let cancelled = false
+
+  return new ReadableStream<V0UIMessageChunk>({
+    async start(controller) {
+      const adapter = new UIMessageStreamAdapter((chunk) => {
+        if (!cancelled) {
+          controller.enqueue(chunk)
+        }
+      })
+
+      try {
+        for await (const update of result.stream) {
+          if (cancelled) {
+            return
+          }
+          adapter.handleUpdate(update)
+        }
+
+        adapter.finish(await result.final)
+      } catch (error) {
+        adapter.fail(error)
+      } finally {
+        if (!cancelled) {
+          controller.close()
+        }
+      }
+    },
+    cancel() {
+      cancelled = true
+    },
+  })
+}
+
+/**
+ * Converts a {@link V0StreamResult} into an AI SDK UI message stream
+ * `Response` (Server-Sent Events), ready to be returned from a route handler
+ * and consumed by `useChat`:
+ *
+ * ```ts
+ * export async function POST(request: Request) {
+ *   const { chatId, message, attachments } = await request.json()
+ *
+ *   return toUIMessageStreamResponse(
+ *     chatId
+ *       ? await v0.messages.sendStream({ chatId, message, attachments })
+ *       : await v0.chats.createStream({ message, attachments }),
+ *   )
+ * }
+ * ```
+ */
+export function toUIMessageStreamResponse(
+  result: V0StreamResult,
+  init?: Omit<Parameters<typeof createUIMessageStreamResponse>[0], 'stream'>,
+): Response {
+  return createUIMessageStreamResponse({
+    ...init,
+    stream: toUIMessageStream(result),
+  })
+}
+
+interface TextPartState {
+  kind: 'text' | 'reasoning'
+  id: string
+  text: string
+  open: boolean
+}
+
+interface DataPartState {
+  kind: 'data'
+  json: string
+}
+
+type PartState = TextPartState | DataPartState
+
+type V0StreamSnapshot = V0StreamUpdate | V0StreamFinal
+
+type V0TextPart = Extract<V0StreamSnapshot['parts'][number], { type: 'text' | 'thinking' }>
+
+type V0DataPart = Exclude<V0StreamSnapshot['parts'][number], { type: 'text' | 'thinking' }>
+
+class UIMessageStreamAdapter {
+  private started = false
+  private chatJson: string | undefined
+  private pendingChat: Serialized<Chat> | undefined
+  private metadataJson: string | undefined
+  private readonly parts: PartState[] = []
+  private readonly usedTextPartIds = new Set<string>()
+
+  constructor(private readonly enqueue: (chunk: V0UIMessageChunk) => void) { }
+
+  handleUpdate(update: V0StreamSnapshot): void {
+    const messageId = update.message?.id ?? messageIdFromEvent(update.event)
+
+    if (!this.started && messageId == null) {
+      this.stashChat(update)
+      return
+    }
+
+    this.ensureStarted(messageId, update)
+    this.syncChat(update)
+    this.syncMetadata(update, messageId)
+    update.parts.forEach((part, index) => this.syncPart(index, part))
+  }
+
+  finish(final: V0StreamFinal): void {
+    const messageId = final.message?.id ?? messageIdFromEvent(final.event)
+
+    this.ensureStarted(messageId, final)
+    this.syncChat(final)
+    final.parts.forEach((part, index) => this.syncPart(index, part))
+
+    for (const part of this.parts) {
+      if (part.kind !== 'data' && part.open) {
+        this.closeTextPart(part)
+      }
+    }
+
+    this.enqueue({
+      type: 'finish',
+      finishReason: final.message?.finishReason ?? undefined,
+      messageMetadata: buildMetadata(final, messageId),
+    })
+  }
+
+  fail(error: unknown): void {
+    this.enqueue({
+      type: 'error',
+      errorText: error instanceof Error ? error.message : 'v0 stream failed',
+    })
+  }
+
+  private ensureStarted(messageId: string | undefined, update: V0StreamSnapshot): void {
+    if (this.started) {
+      return
+    }
+
+    this.started = true
+
+    const metadata = buildMetadata(update, messageId)
+    this.metadataJson = metadata ? JSON.stringify(metadata) : undefined
+    this.enqueue({ type: 'start', messageId, messageMetadata: metadata })
+
+    if (this.pendingChat) {
+      this.enqueue(chatDataChunk(this.pendingChat))
+      this.pendingChat = undefined
+    }
+  }
+
+  private stashChat(update: V0StreamSnapshot): void {
+    const chat = serializeChat(update)
+    if (!chat) {
+      return
+    }
+
+    const json = JSON.stringify(chat)
+    if (json === this.chatJson) {
+      return
+    }
+
+    this.chatJson = json
+    this.pendingChat = chat
+  }
+
+  private syncChat(update: V0StreamSnapshot): void {
+    const chat = serializeChat(update)
+    if (!chat) {
+      return
+    }
+
+    const json = JSON.stringify(chat)
+    if (json === this.chatJson) {
+      return
+    }
+
+    this.chatJson = json
+    this.enqueue(chatDataChunk(chat))
+  }
+
+  private syncMetadata(update: V0StreamSnapshot, messageId: string | undefined): void {
+    const metadata = buildMetadata(update, messageId)
+    if (!metadata) {
+      return
+    }
+
+    const json = JSON.stringify(metadata)
+    if (json === this.metadataJson) {
+      return
+    }
+
+    this.metadataJson = json
+    this.enqueue({ type: 'message-metadata', messageMetadata: metadata })
+  }
+
+  private syncPart(index: number, part: V0StreamSnapshot['parts'][number]): void {
+    if (part.type === 'text' || part.type === 'thinking') {
+      this.syncTextPart(index, part)
+      return
+    }
+
+    this.syncDataPart(index, part)
+  }
+
+  private syncTextPart(index: number, part: V0TextPart): void {
+    const kind = part.type === 'text' ? 'text' : 'reasoning'
+    const existing = this.parts[index]
+    let state: TextPartState
+
+    if (existing?.kind === kind) {
+      state = existing
+    } else {
+      if (existing && existing.kind !== 'data' && existing.open) {
+        this.closeTextPart(existing)
+      }
+      state = this.openTextPart(index, kind, '')
+    }
+
+    if (part.text !== state.text) {
+      if (!state.open) {
+        state = this.openTextPart(index, kind, state.text)
+      }
+
+      const delta = part.text.slice(commonPrefixLength(state.text, part.text))
+      if (delta) {
+        this.enqueue(
+          kind === 'text'
+            ? { type: 'text-delta', id: state.id, delta }
+            : { type: 'reasoning-delta', id: state.id, delta },
+        )
+      }
+      state.text = part.text
+    }
+
+    if (part.finishedAt != null && state.open) {
+      this.closeTextPart(state)
+    }
+  }
+
+  private syncDataPart(index: number, part: V0DataPart): void {
+    const existing = this.parts[index]
+    if (existing && existing.kind !== 'data' && existing.open) {
+      this.closeTextPart(existing)
+    }
+
+    const { type, ...rest } = part
+    const data = serializeDates(rest)
+    const json = JSON.stringify(data)
+
+    if (existing?.kind === 'data' && existing.json === json) {
+      return
+    }
+
+    this.parts[index] = { kind: 'data', json }
+    this.enqueue({ type: `data-${type}`, id: `part-${index}`, data } as V0UIMessageChunk)
+  }
+
+  private openTextPart(index: number, kind: TextPartState['kind'], text: string): TextPartState {
+    const base = `${kind}-${index}`
+    let id = base
+    for (let attempt = 1; this.usedTextPartIds.has(id); attempt++) {
+      id = `${base}-${attempt}`
+    }
+    this.usedTextPartIds.add(id)
+
+    const state: TextPartState = { kind, id, text, open: true }
+    this.parts[index] = state
+    this.enqueue(kind === 'text' ? { type: 'text-start', id } : { type: 'reasoning-start', id })
+    return state
+  }
+
+  private closeTextPart(state: TextPartState): void {
+    state.open = false
+    this.enqueue(
+      state.kind === 'text'
+        ? { type: 'text-end', id: state.id }
+        : { type: 'reasoning-end', id: state.id },
+    )
+  }
+}
+
+function messageIdFromEvent(event: V0StreamEvent): string | undefined {
+  switch (event.object) {
+    case 'message':
+    case 'message.parts.chunk':
+    case 'message.usage': {
+      return event.id
+    }
+    default: {
+      return undefined
+    }
+  }
+}
+
+function buildMetadata(
+  update: V0StreamSnapshot,
+  messageId: string | undefined,
+): V0MessageMetadata | undefined {
+  if (update.message) {
+    const { role: _role, content: _content, parts: _parts, ...metadata } = update.message
+    return serializeDates(metadata)
+  }
+
+  const metadata: V0MessageMetadata = {}
+  if (messageId != null) {
+    metadata.id = messageId
+  }
+  if (update.chat) {
+    metadata.chatId = update.chat.id
+  }
+  if (update.usage) {
+    metadata.usage = update.usage
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined
+}
+
+function serializeChat(update: V0StreamSnapshot): Serialized<Chat> | undefined {
+  if (!update.chat) {
+    return undefined
+  }
+
+  return serializeDates({ ...update.chat, title: update.chat.title ?? update.title })
+}
+
+function chatDataChunk(chat: Serialized<Chat>): V0UIMessageChunk {
+  return { type: 'data-chat', id: 'chat', data: chat, transient: true }
+}
+
+function commonPrefixLength(a: string, b: string): number {
+  const max = Math.min(a.length, b.length)
+  let length = 0
+  while (length < max && a[length] === b[length]) {
+    length++
+  }
+  return length
+}

--- a/packages/v0-sdk/src/ai-sdk/ui-message-stream.ts
+++ b/packages/v0-sdk/src/ai-sdk/ui-message-stream.ts
@@ -74,6 +74,43 @@ export function toUIMessageStreamResponse(
   })
 }
 
+/**
+ * Converts a `v0.chats.resume` result into a `Response` for the reconnect
+ * (`GET`) route handler used by `useChat`'s `resume`. When there is a
+ * generation to attach to it responds like {@link toUIMessageStreamResponse};
+ * when there is nothing to resume (v0 responds with an error, for example 404
+ * when no resumable stream exists) it responds with `204 No Content`, which
+ * `useChat` treats as "nothing to resume".
+ *
+ * ```ts
+ * export async function GET(request: Request) {
+ *   const chatId = new URL(request.url).searchParams.get('chatId')
+ *   if (!chatId) return new Response(null, { status: 204 })
+ *
+ *   return toResumeResponse(v0.chats.resume({ chatId }, { sseMaxRetryAttempts: 1 }))
+ * }
+ * ```
+ */
+export async function toResumeResponse(
+  result: V0StreamResult | Promise<V0StreamResult>,
+  init?: Omit<Parameters<typeof createUIMessageStreamResponse>[0], 'stream'>,
+): Promise<Response> {
+  try {
+    const resolved = await result
+
+    const probe = resolved.stream[Symbol.asyncIterator]()
+    try {
+      await probe.next()
+    } finally {
+      await probe.return?.()
+    }
+
+    return toUIMessageStreamResponse(resolved, init)
+  } catch {
+    return new Response(null, { status: 204 })
+  }
+}
+
 interface TextPartState {
   kind: 'text' | 'reasoning'
   id: string

--- a/packages/v0-sdk/src/ai-sdk/ui-message.ts
+++ b/packages/v0-sdk/src/ai-sdk/ui-message.ts
@@ -1,0 +1,165 @@
+import type { DataUIPart, InferUIMessageChunk, UIMessage } from 'ai'
+import type { Messages } from '../generated/sdk.gen'
+import type { Chat, Message } from '../generated/types.gen'
+
+/**
+ * Maps a v0 API type to its JSON wire format: `Date` fields become ISO 8601
+ * strings, everything else is preserved. UI messages cross the network as
+ * JSON, so timestamps are typed the way they actually arrive in the browser.
+ */
+export type Serialized<T> = T extends Date
+  ? string
+  : T extends Array<infer Item>
+  ? Array<Serialized<Item>>
+  : T extends object
+  ? { [Key in keyof T]: Serialized<T[Key]> }
+  : T
+
+/**
+ * Metadata carried on every {@link V0UIMessage}, derived from {@link Message}.
+ * Everything except `role`, `content`, and `parts` (which the UI message
+ * itself represents) flows through: `id`, `chatId`, `createdAt`, `updatedAt`,
+ * `finishReason`, `attachments`, `authorId`, and `usage`. Fields are partial
+ * because they arrive incrementally while a response streams.
+ */
+export type V0MessageMetadata = Serialized<Partial<Omit<Message, 'role' | 'content' | 'parts'>>>
+
+type V0MessagePart = Message['parts'][number]
+
+type V0DataPartType = Exclude<V0MessagePart['type'], 'text' | 'thinking'>
+
+/**
+ * The AI SDK data parts of a {@link V0UIMessage}, derived from
+ * {@link Message}'s `parts` union. Every v0 part except `text` and `thinking`
+ * (which map to the AI SDK's native `text` and `reasoning` parts) becomes a
+ * `data-*` part carrying the v0 payload, e.g. `data-file-edit`, `data-bash`,
+ * and `data-tool-call`. The extra `data-chat` part is transient: it streams
+ * {@link Chat} snapshots (including the generated title) to `onData` while a
+ * response is being generated, and is not persisted on the message.
+ */
+export type V0DataParts = {
+  [Type in V0DataPartType]: Serialized<Omit<Extract<V0MessagePart, { type: Type }>, 'type'>>
+} & {
+  chat: Serialized<Chat>
+}
+
+/**
+ * A v0 {@link Message} as an AI SDK `UIMessage`. Pass it as the message type
+ * of `useChat` and every part, metadata field, and data part is fully typed:
+ *
+ * ```ts
+ * useChat<V0UIMessage>()
+ * ```
+ */
+export type V0UIMessage = UIMessage<V0MessageMetadata, V0DataParts, Record<never, never>>
+
+/** The AI SDK stream chunk type produced for a {@link V0UIMessage}. */
+export type V0UIMessageChunk = InferUIMessageChunk<V0UIMessage>
+
+/** @internal */
+export function serializeDates<T>(value: T): Serialized<T> {
+  if (value instanceof Date) {
+    return value.toISOString() as Serialized<T>
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeDates(item)) as Serialized<T>
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, serializeDates(entry)]),
+    ) as Serialized<T>
+  }
+
+  return value as Serialized<T>
+}
+
+/**
+ * Converts a v0 {@link Message} into a {@link V0UIMessage}. Attachments become
+ * AI SDK `file` parts, `text` and `thinking` parts become `text` and
+ * `reasoning` parts, and every other part becomes its corresponding `data-*`
+ * part. The remaining message fields are preserved as metadata.
+ */
+export function toUIMessage(message: Message): V0UIMessage {
+  const { role, content: _content, parts, ...metadata } = message
+
+  const uiParts: V0UIMessage['parts'] = (message.attachments ?? []).map((attachment) => ({
+    type: 'file',
+    url: attachment.url,
+    mediaType: attachment.contentType ?? 'application/octet-stream',
+    filename: attachment.name,
+  }))
+
+  parts.forEach((part, index) => {
+    uiParts.push(toUIMessagePart(part, index))
+  })
+
+  return {
+    id: message.id,
+    role,
+    metadata: serializeDates(metadata),
+    parts: uiParts,
+  }
+}
+
+/**
+ * Converts v0 messages (for example from `v0.messages.list`, which returns
+ * them newest first) into {@link V0UIMessage}s ordered oldest first, ready to
+ * be passed as the initial `messages` of `useChat`.
+ */
+export function toUIMessages(messages: ReadonlyArray<Message>): V0UIMessage[] {
+  return [...messages]
+    .sort((a, b) => {
+      const delta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      if (delta !== 0) {
+        return delta
+      }
+      if (a.role === b.role) {
+        return 0
+      }
+      return a.role === 'user' ? -1 : 1
+    })
+    .map((message) => toUIMessage(message))
+}
+
+type MessagesSendParameters = Parameters<Messages['send']>[0]
+
+/**
+ * Extracts the v0 `message` text and `attachments` from an AI SDK `UIMessage`,
+ * ready to be spread into `v0.chats.create`, `v0.chats.createStream`,
+ * `v0.messages.send`, or `v0.messages.sendStream`.
+ */
+export function fromUIMessage(
+  message: UIMessage,
+): Pick<MessagesSendParameters, 'message' | 'attachments'> {
+  const text = message.parts
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('\n\n')
+
+  const attachments = message.parts
+    .filter((part) => part.type === 'file')
+    .map((part) => ({ url: part.url }))
+
+  return attachments.length > 0 ? { message: text, attachments } : { message: text }
+}
+
+function toUIMessagePart(part: V0MessagePart, index: number): V0UIMessage['parts'][number] {
+  switch (part.type) {
+    case 'text': {
+      return { type: 'text', text: part.text, state: 'done' }
+    }
+    case 'thinking': {
+      return { type: 'reasoning', text: part.text, state: 'done' }
+    }
+    default: {
+      const { type, ...data } = part
+      return {
+        type: `data-${type}`,
+        id: `part-${index}`,
+        data: serializeDates(data),
+      } as DataUIPart<V0DataParts>
+    }
+  }
+}

--- a/packages/v0-sdk/src/id.tsx
+++ b/packages/v0-sdk/src/id.tsx
@@ -1,0 +1,3 @@
+import { createId } from 'legid' // v0 uses legid for chat IDs
+
+export const createChatId = () => createId({ approximateLength: 11, step: 3 })

--- a/packages/v0-sdk/src/index.ts
+++ b/packages/v0-sdk/src/index.ts
@@ -10,6 +10,8 @@ export type { FetchPreviewOptions } from './preview-proxy'
 export { vercelOidcAuth, type VercelOidcAuthOptions } from './vercel-oidc'
 export type * from './generated/types.gen'
 
+export { createChatId } from './id'
+
 type CreateClientConfig = NonNullable<Parameters<typeof createClient>[0]>
 type CreateV0ClientConfig = CreateClientConfig & {
   /**
@@ -130,10 +132,7 @@ function wrapChats(chats: GeneratedChats): V0Client['chats'] {
       }
 
       if (property === 'resume') {
-        return async (
-          parameters: ChatsResumeOptions,
-          options?: ChatsResumeRequestOptions,
-        ) => {
+        return async (parameters: ChatsResumeOptions, options?: ChatsResumeRequestOptions) => {
           const result = await target.resume(parameters, options)
           return createV0StreamResult(result.stream)
         }

--- a/packages/v0-sdk/src/react/index.ts
+++ b/packages/v0-sdk/src/react/index.ts
@@ -1,0 +1,126 @@
+'use client'
+
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import type { ChatInit } from 'ai'
+import { fromUIMessage } from '../ai-sdk/ui-message'
+import type { V0UIMessage } from '../ai-sdk/ui-message'
+import type { Chat } from '../generated/types.gen'
+import { useNewChatId } from './use-new-chat-id'
+
+export type {
+  Serialized,
+  V0DataParts,
+  V0MessageMetadata,
+  V0UIMessage,
+  V0UIMessageChunk,
+} from '../ai-sdk/ui-message'
+
+type TransportOptions = NonNullable<
+  ConstructorParameters<typeof DefaultChatTransport<V0UIMessage>>[0]
+>
+
+type UseChatPassthroughOptions = Pick<
+  NonNullable<Parameters<typeof useChat<V0UIMessage>>[0]>,
+  'experimental_throttle' | 'resume'
+>
+
+export type UseV0ChatOptions = Omit<ChatInit<V0UIMessage>, 'id' | 'transport'> &
+  Pick<TransportOptions, 'api' | 'body' | 'credentials' | 'fetch' | 'headers'> &
+  UseChatPassthroughOptions & {
+    /**
+     * The id of the v0 chat to continue. Omit it to start a new chat: v0
+     * assigns the id when the first message is sent, and it is picked up from
+     * the streamed message metadata.
+     */
+    chatId?: Chat['id']
+  }
+
+export type UseV0ChatHelpers = ReturnType<typeof useChat<V0UIMessage>> & {
+  /**
+   * The id of the v0 chat: the `chatId` option when provided, otherwise
+   * derived from the latest message metadata once v0 creates the chat.
+   * Persist it (for example in the URL) to continue the conversation later.
+   */
+  chatId: Chat['id'] | undefined
+}
+
+/**
+ * `useChat` preconfigured for v0: messages are typed as {@link V0UIMessage},
+ * requests carry the `{ chatId, message, attachments }` body expected by a
+ * v0-backed route handler, and the v0 chat id is derived from the
+ * conversation automatically.
+ *
+ * ```tsx
+ * const { messages, sendMessage, chatId } = useV0Chat()
+ * ```
+ *
+ * Pass `resume: true` together with `chatId` to reconnect to a generation
+ * that is still streaming.
+ */
+export function useV0Chat(options: UseV0ChatOptions = {}): UseV0ChatHelpers {
+  const {
+    api,
+    body,
+    chatId,
+    credentials,
+    experimental_throttle,
+    fetch,
+    headers,
+    resume,
+    ...chatInit
+  } = options
+
+  const { nextChatId, generateNextChatId } = useNewChatId(chatId)
+
+  let resolvedChatId = chatId ?? nextChatId ?? chatIdFromMessages(options.messages)
+
+  const transport = new DefaultChatTransport<V0UIMessage>({
+    api,
+    body,
+    credentials,
+    fetch,
+    headers,
+    prepareSendMessagesRequest: async ({ body, messages }) => {
+      const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user')
+
+      let id = resolvedChatId ?? chatIdFromMessages(messages) ?? (await generateNextChatId())
+
+      return {
+        body: { ...body, chatId: id, ...(lastUserMessage ? fromUIMessage(lastUserMessage) : {}) },
+      }
+    },
+    prepareReconnectToStreamRequest: ({ api, id }) => ({
+      api: `${api}?chatId=${encodeURIComponent(id)}`,
+    }),
+  })
+
+  const helpers = useChat<V0UIMessage>({
+    ...chatInit,
+    id: resolvedChatId,
+    transport,
+    experimental_throttle,
+    resume,
+  })
+
+  if (resolvedChatId == null) {
+    resolvedChatId = chatIdFromMessages(helpers.messages)
+  }
+
+  return { ...helpers, chatId: resolvedChatId }
+}
+
+function chatIdFromMessages(messages: readonly V0UIMessage[] | undefined): Chat['id'] | undefined {
+  if (messages == null) {
+    return undefined
+  }
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const chatId = messages[index]?.metadata?.chatId
+    if (chatId != null) {
+      return chatId
+    }
+  }
+
+  return undefined
+}

--- a/packages/v0-sdk/src/react/use-new-chat-id.ts
+++ b/packages/v0-sdk/src/react/use-new-chat-id.ts
@@ -1,0 +1,37 @@
+'use client'
+import { useState, useRef, useCallback, useEffect } from 'react'
+import type { Chat } from '../generated'
+import { createChatId } from '../id'
+
+// since chatId is async with crypto, we generate it on mount
+// and we use it for the first message, ideally.
+export function useNewChatId(chatId: Chat['id'] | undefined) {
+  const [nextChatId, setNextChatId] = useState<string | undefined>(undefined)
+
+  const nextChatIdPromiseRef = useRef<Promise<string> | undefined>(undefined)
+
+  const generateNextChatId = useCallback(() => {
+    if (!nextChatIdPromiseRef.current) {
+      nextChatIdPromiseRef.current = createChatId()
+        .then((id) => {
+          setNextChatId(id)
+          return id
+        })
+        .finally(() => {
+          nextChatIdPromiseRef.current = undefined
+        })
+    }
+    return nextChatIdPromiseRef.current
+  }, [])
+
+  useEffect(
+    function generateNextChatId() {
+      if (chatId || nextChatId) return
+
+      generateNextChatId()
+    },
+    [chatId, nextChatId, generateNextChatId],
+  )
+
+  return { nextChatId, generateNextChatId }
+}

--- a/packages/v0-sdk/tests/helpers.ts
+++ b/packages/v0-sdk/tests/helpers.ts
@@ -1,0 +1,79 @@
+import type { Chat, Message } from '../src/generated/types.gen'
+import { createV0StreamResult } from '../src/stream/result'
+import type { V0StreamEvent, V0StreamResult } from '../src/stream/result'
+
+export const createdAt = new Date('2026-01-01T00:00:00.000Z')
+export const updatedAt = new Date('2026-01-01T00:00:05.000Z')
+
+export function usage(total: number): Message['usage'] {
+  const values = { input: total, output: 0, cacheRead: 0, cacheWrite: 0, total }
+  return { tokens: values, creditsCost: values }
+}
+
+export function assistantMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg_1',
+    chatId: 'chat_1',
+    role: 'assistant',
+    createdAt,
+    updatedAt,
+    content: '',
+    parts: [],
+    finishReason: null,
+    authorId: null,
+    usage: usage(0),
+    ...overrides,
+  }
+}
+
+export function userMessage(overrides: Partial<Message> = {}): Message {
+  return assistantMessage({
+    id: 'msg_0',
+    role: 'user',
+    authorId: 'user_1',
+    ...overrides,
+  })
+}
+
+export function chatSnapshot(overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: 'chat_1',
+    privacy: 'private',
+    createdAt,
+    authorId: 'user_1',
+    metadata: {},
+    writePermission: true,
+    ...overrides,
+  }
+}
+
+export const serializedAssistantMetadata = {
+  id: 'msg_1',
+  chatId: 'chat_1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:05.000Z',
+  finishReason: null,
+  authorId: null,
+}
+
+export function streamOf(events: V0StreamEvent[]): V0StreamResult {
+  return createV0StreamResult(
+    (async function* () {
+      for (const event of events) {
+        yield event
+      }
+    })(),
+  )
+}
+
+export async function readAll<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const values: T[] = []
+  const reader = stream.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      return values
+    }
+    values.push(value)
+  }
+}

--- a/packages/v0-sdk/tests/setup.ts
+++ b/packages/v0-sdk/tests/setup.ts
@@ -1,0 +1,49 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean
+}
+
+const preservedGlobals = [
+  'AbortController',
+  'AbortSignal',
+  'Blob',
+  'crypto',
+  'fetch',
+  'File',
+  'FormData',
+  'Headers',
+  'MessageChannel',
+  'MessagePort',
+  'performance',
+  'queueMicrotask',
+  'ReadableStream',
+  'Request',
+  'Response',
+  'structuredClone',
+  'TextDecoder',
+  'TextDecoderStream',
+  'TextEncoder',
+  'TextEncoderStream',
+  'TransformStream',
+  'URL',
+  'URLSearchParams',
+  'WritableStream',
+] as const
+
+const globalRecord = globalThis as unknown as Record<string, unknown>
+const snapshot = new Map<string, unknown>()
+
+for (const key of preservedGlobals) {
+  if (key in globalRecord) {
+    snapshot.set(key, globalRecord[key])
+  }
+}
+
+GlobalRegistrator.register()
+
+for (const [key, value] of snapshot) {
+  globalRecord[key] = value
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true

--- a/packages/v0-sdk/tests/ui-message-stream.test.ts
+++ b/packages/v0-sdk/tests/ui-message-stream.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 import { readUIMessageStream } from 'ai'
-import { toUIMessage, toUIMessageStream, toUIMessageStreamResponse } from '../src/ai-sdk'
+import {
+  toResumeResponse,
+  toUIMessage,
+  toUIMessageStream,
+  toUIMessageStreamResponse,
+} from '../src/ai-sdk'
 import type { V0UIMessage, V0UIMessageChunk } from '../src/ai-sdk'
 import type { Message } from '../src/generated/types.gen'
 import { diff } from '../src/stream/diffpatch'
+import { createV0StreamResult } from '../src/stream/result'
 import type { V0StreamEvent } from '../src/stream/result'
 import {
   assistantMessage,
@@ -477,6 +483,68 @@ describe('toUIMessageStreamResponse', () => {
     )
 
     expect(response.status).toBe(201)
+    expect(response.headers.get('x-chat-id')).toBe('chat_1')
+
+    await response.body?.cancel()
+  })
+})
+
+describe('toResumeResponse', () => {
+  test('streams the full response when a generation is resumable', async () => {
+    const response = await toResumeResponse(
+      streamOf([
+        { ...chatSnapshot(), object: 'chat' },
+        {
+          id: 'msg_9',
+          object: 'message.parts.chunk',
+          delta: diff([], [{ type: 'text', text: 'Still going' }]),
+        },
+      ]),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toStartWith('text/event-stream')
+
+    const body = await response.text()
+    expect(body).toContain('"type":"start"')
+    expect(body).toContain('"data-chat"')
+    expect(body).toContain('Still going')
+    expect(body).toContain('"type":"finish"')
+  })
+
+  test('responds with 204 when the resume request rejects', async () => {
+    const response = await toResumeResponse(
+      Promise.reject(new Error('SSE failed: 404 Not Found')),
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.body).toBeNull()
+  })
+
+  test('responds with 204 when the stream fails before its first event', async () => {
+    const response = await toResumeResponse(
+      createV0StreamResult(
+        (async function* () {
+          throw new Error('SSE failed: 404 Not Found')
+        })(),
+      ),
+    )
+
+    expect(response.status).toBe(204)
+  })
+
+  test('responds with 204 when the stream ends without events', async () => {
+    const response = await toResumeResponse(streamOf([]))
+
+    expect(response.status).toBe(204)
+  })
+
+  test('passes response init through when streaming', async () => {
+    const response = await toResumeResponse(
+      streamOf([{ ...assistantMessage(), object: 'message' }]),
+      { headers: { 'x-chat-id': 'chat_1' } },
+    )
+
     expect(response.headers.get('x-chat-id')).toBe('chat_1')
 
     await response.body?.cancel()

--- a/packages/v0-sdk/tests/ui-message-stream.test.ts
+++ b/packages/v0-sdk/tests/ui-message-stream.test.ts
@@ -1,0 +1,484 @@
+import { describe, expect, test } from 'bun:test'
+import { readUIMessageStream } from 'ai'
+import { toUIMessage, toUIMessageStream, toUIMessageStreamResponse } from '../src/ai-sdk'
+import type { V0UIMessage, V0UIMessageChunk } from '../src/ai-sdk'
+import type { Message } from '../src/generated/types.gen'
+import { diff } from '../src/stream/diffpatch'
+import type { V0StreamEvent } from '../src/stream/result'
+import {
+  assistantMessage,
+  chatSnapshot,
+  readAll,
+  serializedAssistantMetadata,
+  streamOf,
+  updatedAt,
+  usage,
+} from './helpers'
+
+function collect(events: V0StreamEvent[]): Promise<V0UIMessageChunk[]> {
+  return readAll(toUIMessageStream(streamOf(events)))
+}
+
+function partsChunks(id: string, snapshots: Array<Message['parts']>): V0StreamEvent[] {
+  return snapshots.slice(1).map((next, index) => ({
+    id,
+    object: 'message.parts.chunk' as const,
+    delta: diff(snapshots[index], next),
+  }))
+}
+
+describe('toUIMessageStream', () => {
+  test('adapts a message stream to the AI SDK chunk protocol', async () => {
+    const snapshots: Array<Message['parts']> = [
+      [],
+      [{ type: 'thinking', text: 'Consider' }],
+      [{ type: 'thinking', text: 'Considering...', finishedAt: updatedAt }],
+      [
+        { type: 'thinking', text: 'Considering...', finishedAt: updatedAt },
+        { type: 'file-edit', operation: 'create', path: 'app/page.tsx' },
+      ],
+      [
+        { type: 'thinking', text: 'Considering...', finishedAt: updatedAt },
+        { type: 'file-edit', operation: 'create', path: 'app/page.tsx', finishedAt: updatedAt },
+        { type: 'text', text: 'Done! ' },
+      ],
+      [
+        { type: 'thinking', text: 'Considering...', finishedAt: updatedAt },
+        { type: 'file-edit', operation: 'create', path: 'app/page.tsx', finishedAt: updatedAt },
+        { type: 'text', text: 'Done! Enjoy.' },
+      ],
+    ]
+
+    const chunks = await collect([
+      { ...assistantMessage(), object: 'message' },
+      ...partsChunks('msg_1', snapshots),
+      { id: 'msg_1', object: 'message.usage', usage: usage(42) },
+    ])
+
+    expect(chunks).toEqual([
+      {
+        type: 'start',
+        messageId: 'msg_1',
+        messageMetadata: { ...serializedAssistantMetadata, usage: usage(0) },
+      },
+      { type: 'reasoning-start', id: 'reasoning-0' },
+      { type: 'reasoning-delta', id: 'reasoning-0', delta: 'Consider' },
+      { type: 'reasoning-delta', id: 'reasoning-0', delta: 'ing...' },
+      { type: 'reasoning-end', id: 'reasoning-0' },
+      {
+        type: 'data-file-edit',
+        id: 'part-1',
+        data: { operation: 'create', path: 'app/page.tsx' },
+      },
+      {
+        type: 'data-file-edit',
+        id: 'part-1',
+        data: { operation: 'create', path: 'app/page.tsx', finishedAt: '2026-01-01T00:00:05.000Z' },
+      },
+      { type: 'text-start', id: 'text-2' },
+      { type: 'text-delta', id: 'text-2', delta: 'Done! ' },
+      { type: 'text-delta', id: 'text-2', delta: 'Enjoy.' },
+      {
+        type: 'message-metadata',
+        messageMetadata: { ...serializedAssistantMetadata, usage: usage(42) },
+      },
+      { type: 'text-end', id: 'text-2' },
+      {
+        type: 'finish',
+        finishReason: undefined,
+        messageMetadata: { ...serializedAssistantMetadata, usage: usage(42) },
+      },
+    ])
+  })
+
+  test('delays start until the message id is known and streams transient chat data', async () => {
+    const chunks = await collect([
+      { ...chatSnapshot(), object: 'chat' },
+      { id: 'chat_1', object: 'chat.title', delta: 'My App' },
+      {
+        id: 'msg_9',
+        object: 'message.parts.chunk',
+        delta: diff([], [{ type: 'text', text: 'Hi' }]),
+      },
+    ])
+
+    expect(chunks).toEqual([
+      {
+        type: 'start',
+        messageId: 'msg_9',
+        messageMetadata: { id: 'msg_9', chatId: 'chat_1' },
+      },
+      {
+        type: 'data-chat',
+        id: 'chat',
+        transient: true,
+        data: {
+          id: 'chat_1',
+          privacy: 'private',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          authorId: 'user_1',
+          metadata: {},
+          writePermission: true,
+          title: 'My App',
+        },
+      },
+      { type: 'text-start', id: 'text-0' },
+      { type: 'text-delta', id: 'text-0', delta: 'Hi' },
+      { type: 'text-end', id: 'text-0' },
+      {
+        type: 'finish',
+        finishReason: undefined,
+        messageMetadata: { id: 'msg_9', chatId: 'chat_1' },
+      },
+    ])
+  })
+
+  test('re-emits chat data when the chat changes after start', async () => {
+    const chunks = await collect([
+      { ...chatSnapshot(), object: 'chat' },
+      {
+        id: 'msg_9',
+        object: 'message.parts.chunk',
+        delta: diff([], [{ type: 'text', text: 'Hi' }]),
+      },
+      { id: 'chat_1', object: 'chat.title', delta: 'Landing page' },
+    ])
+
+    const chatChunks = chunks.filter((chunk) => chunk.type === 'data-chat')
+
+    expect(chatChunks).toHaveLength(2)
+    expect(chatChunks[0]).toMatchObject({ id: 'chat', transient: true, data: { title: undefined } })
+    expect(chatChunks[1]).toMatchObject({
+      id: 'chat',
+      transient: true,
+      data: { title: 'Landing page' },
+    })
+  })
+
+  test('starts immediately when the first event carries a message id', async () => {
+    const chunks = await collect([{ id: 'msg_1', object: 'message.usage', usage: usage(7) }])
+
+    expect(chunks[0]).toEqual({
+      type: 'start',
+      messageId: 'msg_1',
+      messageMetadata: { id: 'msg_1', usage: usage(7) },
+    })
+  })
+
+  test('emits a start and finish for chat-only streams', async () => {
+    const chunks = await collect([{ ...chatSnapshot(), object: 'chat' }])
+
+    expect(chunks).toEqual([
+      { type: 'start', messageId: undefined, messageMetadata: { chatId: 'chat_1' } },
+      {
+        type: 'data-chat',
+        id: 'chat',
+        transient: true,
+        data: {
+          id: 'chat_1',
+          privacy: 'private',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          authorId: 'user_1',
+          metadata: {},
+          writePermission: true,
+          title: undefined,
+        },
+      },
+      { type: 'finish', finishReason: undefined, messageMetadata: { chatId: 'chat_1' } },
+    ])
+  })
+
+  test('does not repeat metadata or data chunks for unchanged state', async () => {
+    const parts: Message['parts'] = [{ type: 'bash', command: 'ls', output: 'ok' }]
+
+    const chunks = await collect([
+      { ...assistantMessage({ parts }), object: 'message' },
+      { ...assistantMessage({ parts }), object: 'message' },
+      { id: 'msg_1', object: 'message.usage', usage: usage(0) },
+    ])
+
+    expect(chunks.filter((chunk) => chunk.type === 'data-bash')).toHaveLength(1)
+    expect(chunks.filter((chunk) => chunk.type === 'message-metadata')).toHaveLength(0)
+  })
+
+  test('re-emits a data part when its payload changes', async () => {
+    const chunks = await collect([
+      {
+        ...assistantMessage({ parts: [{ type: 'bash', command: 'bun test' }] }),
+        object: 'message',
+      },
+      {
+        ...assistantMessage({
+          parts: [{ type: 'bash', command: 'bun test', output: '11 pass', exitCode: 0 }],
+        }),
+        object: 'message',
+      },
+    ])
+
+    expect(chunks.filter((chunk) => chunk.type === 'data-bash')).toEqual([
+      { type: 'data-bash', id: 'part-0', data: { command: 'bun test' } },
+      {
+        type: 'data-bash',
+        id: 'part-0',
+        data: { command: 'bun test', output: '11 pass', exitCode: 0 },
+      },
+    ])
+  })
+
+  test('serializes Date timestamps inside streamed parts', async () => {
+    const chunks = await collect([
+      {
+        ...assistantMessage({
+          parts: [{ type: 'search', scope: 'repo', query: 'button', startedAt: updatedAt }],
+        }),
+        object: 'message',
+      },
+    ])
+
+    expect(chunks.find((chunk) => chunk.type === 'data-search')).toEqual({
+      type: 'data-search',
+      id: 'part-0',
+      data: { scope: 'repo', query: 'button', startedAt: '2026-01-01T00:00:05.000Z' },
+    })
+  })
+
+  test('streams interleaved text and reasoning parts with index-scoped ids', async () => {
+    const snapshots: Array<Message['parts']> = [
+      [],
+      [{ type: 'text', text: 'One' }],
+      [
+        { type: 'text', text: 'One', finishedAt: updatedAt },
+        { type: 'thinking', text: 'Two' },
+      ],
+      [
+        { type: 'text', text: 'One', finishedAt: updatedAt },
+        { type: 'thinking', text: 'Two', finishedAt: updatedAt },
+        { type: 'text', text: 'Three' },
+      ],
+    ]
+
+    const chunks = await collect([
+      { ...assistantMessage(), object: 'message' },
+      ...partsChunks('msg_1', snapshots),
+    ])
+
+    expect(
+      chunks.filter(
+        (chunk) => chunk.type.startsWith('text-') || chunk.type.startsWith('reasoning-'),
+      ),
+    ).toEqual([
+      { type: 'text-start', id: 'text-0' },
+      { type: 'text-delta', id: 'text-0', delta: 'One' },
+      { type: 'text-end', id: 'text-0' },
+      { type: 'reasoning-start', id: 'reasoning-1' },
+      { type: 'reasoning-delta', id: 'reasoning-1', delta: 'Two' },
+      { type: 'reasoning-end', id: 'reasoning-1' },
+      { type: 'text-start', id: 'text-2' },
+      { type: 'text-delta', id: 'text-2', delta: 'Three' },
+      { type: 'text-end', id: 'text-2' },
+    ])
+  })
+
+  test('reopens a finished text part under a fresh id when more text arrives', async () => {
+    const chunks = await collect([
+      {
+        ...assistantMessage({ parts: [{ type: 'text', text: 'Hello', finishedAt: updatedAt }] }),
+        object: 'message',
+      },
+      {
+        ...assistantMessage({
+          parts: [{ type: 'text', text: 'Hello world', finishedAt: updatedAt }],
+          finishReason: 'stop',
+        }),
+        object: 'message',
+      },
+    ])
+
+    expect(chunks.filter((chunk) => chunk.type.startsWith('text-'))).toEqual([
+      { type: 'text-start', id: 'text-0' },
+      { type: 'text-delta', id: 'text-0', delta: 'Hello' },
+      { type: 'text-end', id: 'text-0' },
+      { type: 'text-start', id: 'text-0-1' },
+      { type: 'text-delta', id: 'text-0-1', delta: ' world' },
+      { type: 'text-end', id: 'text-0-1' },
+    ])
+
+    expect(chunks.at(-1)).toMatchObject({ type: 'finish', finishReason: 'stop' })
+  })
+
+  test('emits only the diverging suffix when open text is rewritten', async () => {
+    const chunks = await collect([
+      {
+        ...assistantMessage({ parts: [{ type: 'text', text: 'Hello world' }] }),
+        object: 'message',
+      },
+      {
+        ...assistantMessage({ parts: [{ type: 'text', text: 'Hello there' }] }),
+        object: 'message',
+      },
+    ])
+
+    expect(chunks.filter((chunk) => chunk.type === 'text-delta')).toEqual([
+      { type: 'text-delta', id: 'text-0', delta: 'Hello world' },
+      { type: 'text-delta', id: 'text-0', delta: 'there' },
+    ])
+  })
+
+  test('closes an open text part when the part type changes at its index', async () => {
+    const chunks = await collect([
+      {
+        ...assistantMessage({ parts: [{ type: 'text', text: 'Working' }] }),
+        object: 'message',
+      },
+      {
+        ...assistantMessage({ parts: [{ type: 'bash', command: 'ls' }] }),
+        object: 'message',
+      },
+      {
+        ...assistantMessage({
+          parts: [{ type: 'text', text: 'Recovered' }],
+        }),
+        object: 'message',
+      },
+    ])
+
+    expect(
+      chunks.filter((chunk) => chunk.type.startsWith('text-') || chunk.type === 'data-bash'),
+    ).toEqual([
+      { type: 'text-start', id: 'text-0' },
+      { type: 'text-delta', id: 'text-0', delta: 'Working' },
+      { type: 'text-end', id: 'text-0' },
+      { type: 'data-bash', id: 'part-0', data: { command: 'ls' } },
+      { type: 'text-start', id: 'text-0-1' },
+      { type: 'text-delta', id: 'text-0-1', delta: 'Recovered' },
+      { type: 'text-end', id: 'text-0-1' },
+    ])
+  })
+
+  test('carries the finish reason from the final message snapshot', async () => {
+    const chunks = await collect([
+      { ...assistantMessage(), object: 'message' },
+      { ...assistantMessage({ finishReason: 'tool-calls' }), object: 'message' },
+    ])
+
+    expect(chunks.at(-1)).toMatchObject({ type: 'finish', finishReason: 'tool-calls' })
+  })
+
+  test('emits an error chunk when the stream fails before starting', async () => {
+    const chunks = await collect([
+      { ...chatSnapshot(), object: 'chat' },
+      { id: 'err_1', object: 'error', message: 'boom', code: 'internal' },
+    ])
+
+    expect(chunks).toEqual([{ type: 'error', errorText: 'boom' }])
+  })
+
+  test('emits an error chunk after streamed content when the stream fails mid-flight', async () => {
+    const chunks = await collect([
+      {
+        ...assistantMessage({ parts: [{ type: 'text', text: 'Half' }] }),
+        object: 'message',
+      },
+      { id: 'err_1', object: 'error', message: 'quota exceeded' },
+    ])
+
+    expect(chunks.at(0)).toMatchObject({ type: 'start', messageId: 'msg_1' })
+    expect(chunks.filter((chunk) => chunk.type === 'text-delta')).toEqual([
+      { type: 'text-delta', id: 'text-0', delta: 'Half' },
+    ])
+    expect(chunks.at(-1)).toEqual({ type: 'error', errorText: 'quota exceeded' })
+    expect(chunks.some((chunk) => chunk.type === 'finish')).toBe(false)
+  })
+
+  test('emits an error chunk for a stream that ends without events', async () => {
+    const chunks = await collect([])
+
+    expect(chunks).toEqual([
+      { type: 'error', errorText: 'v0 stream ended before sending an event' },
+    ])
+  })
+
+  test('replays the same chunks for late subscribers of a shared result', async () => {
+    const result = streamOf([
+      { ...assistantMessage({ parts: [{ type: 'text', text: 'Hi' }] }), object: 'message' },
+    ])
+
+    const first = await readAll(toUIMessageStream(result))
+    const second = await readAll(toUIMessageStream(result))
+
+    expect(second).toEqual(first)
+  })
+
+  test('stops consuming when the reader cancels', async () => {
+    const reader = toUIMessageStream(
+      streamOf([
+        { ...assistantMessage({ parts: [{ type: 'text', text: 'Hi' }] }), object: 'message' },
+        { ...assistantMessage({ finishReason: 'stop' }), object: 'message' },
+      ]),
+    ).getReader()
+
+    const { value } = await reader.read()
+    expect(value).toMatchObject({ type: 'start' })
+
+    await reader.cancel()
+  })
+
+  test('assembles the same message that toUIMessage produces from the final snapshot', async () => {
+    const finalMessage = assistantMessage({
+      content: 'Done!',
+      finishReason: 'stop',
+      usage: usage(7),
+      parts: [
+        { type: 'thinking', text: 'Plan', finishedAt: updatedAt },
+        { type: 'search', scope: 'web', query: 'best practices' },
+        { type: 'text', text: 'Done!' },
+      ],
+    })
+
+    const events: V0StreamEvent[] = [
+      { ...assistantMessage(), object: 'message' },
+      { id: 'msg_1', object: 'message.parts.chunk', delta: diff([], finalMessage.parts) },
+      { ...finalMessage, object: 'message' },
+    ]
+
+    let assembled: V0UIMessage | undefined
+    for await (const state of readUIMessageStream<V0UIMessage>({
+      stream: toUIMessageStream(streamOf(events)),
+    })) {
+      assembled = state
+    }
+
+    const converted = toUIMessage(finalMessage)
+    expect(assembled?.id).toBe(converted.id)
+    expect(assembled?.role).toBe(converted.role)
+    expect(assembled?.parts).toEqual(converted.parts)
+    expect(assembled?.metadata).toEqual(converted.metadata)
+  })
+})
+
+describe('toUIMessageStreamResponse', () => {
+  test('returns an AI SDK SSE response', async () => {
+    const response = toUIMessageStreamResponse(
+      streamOf([{ ...assistantMessage({ finishReason: 'stop' }), object: 'message' }]),
+    )
+
+    expect(response.headers.get('content-type')).toStartWith('text/event-stream')
+
+    const body = await response.text()
+    expect(body).toContain('data: {"type":"start"')
+    expect(body).toContain('"type":"finish"')
+    expect(body).toContain('data: [DONE]')
+  })
+
+  test('passes response init through', async () => {
+    const response = toUIMessageStreamResponse(
+      streamOf([{ ...assistantMessage(), object: 'message' }]),
+      { status: 201, headers: { 'x-chat-id': 'chat_1' } },
+    )
+
+    expect(response.status).toBe(201)
+    expect(response.headers.get('x-chat-id')).toBe('chat_1')
+
+    await response.body?.cancel()
+  })
+})

--- a/packages/v0-sdk/tests/ui-message.test.ts
+++ b/packages/v0-sdk/tests/ui-message.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from 'bun:test'
+import { fromUIMessage, toUIMessage, toUIMessages } from '../src/ai-sdk'
+import { serializeDates } from '../src/ai-sdk/ui-message'
+import type { Message } from '../src/generated/types.gen'
+import {
+  assistantMessage,
+  createdAt,
+  serializedAssistantMetadata,
+  updatedAt,
+  usage,
+  userMessage,
+} from './helpers'
+
+describe('serializeDates', () => {
+  test('converts Date values to ISO strings at any depth', () => {
+    expect(
+      serializeDates({
+        when: createdAt,
+        nested: { list: [updatedAt, 'keep', 7, null] },
+      }),
+    ).toEqual({
+      when: '2026-01-01T00:00:00.000Z',
+      nested: { list: ['2026-01-01T00:00:05.000Z', 'keep', 7, null] },
+    })
+  })
+
+  test('preserves primitives, null, and undefined', () => {
+    expect(serializeDates('text')).toBe('text')
+    expect(serializeDates(42)).toBe(42)
+    expect(serializeDates(true)).toBe(true)
+    expect(serializeDates(null)).toBeNull()
+    expect(serializeDates(undefined)).toBeUndefined()
+    expect(serializeDates({ value: undefined })).toEqual({ value: undefined })
+  })
+})
+
+describe('toUIMessage', () => {
+  test('maps every v0 part type onto the AI SDK part union', () => {
+    const message = assistantMessage({
+      parts: [
+        { type: 'text', text: 'Hello' },
+        { type: 'thinking', text: 'Pondering' },
+        { type: 'file-read', paths: ['app/page.tsx', 'app/layout.tsx'] },
+        { type: 'file-edit', operation: 'rename', path: 'a.ts', toPath: 'b.ts' },
+        { type: 'search', scope: 'web', query: 'react 19' },
+        { type: 'bash', command: 'bun test', output: 'ok', exitCode: 0, isDangerous: false },
+        { type: 'tool-call', name: 'get_weather', input: { city: 'SF' }, output: 62, status: 'ok' },
+        {
+          type: 'agent-action',
+          name: 'manage_todos',
+          summary: 'Updated todos',
+          data: { count: 3 },
+        },
+      ],
+    })
+
+    expect(toUIMessage(message).parts).toEqual([
+      { type: 'text', text: 'Hello', state: 'done' },
+      { type: 'reasoning', text: 'Pondering', state: 'done' },
+      { type: 'data-file-read', id: 'part-2', data: { paths: ['app/page.tsx', 'app/layout.tsx'] } },
+      {
+        type: 'data-file-edit',
+        id: 'part-3',
+        data: { operation: 'rename', path: 'a.ts', toPath: 'b.ts' },
+      },
+      { type: 'data-search', id: 'part-4', data: { scope: 'web', query: 'react 19' } },
+      {
+        type: 'data-bash',
+        id: 'part-5',
+        data: { command: 'bun test', output: 'ok', exitCode: 0, isDangerous: false },
+      },
+      {
+        type: 'data-tool-call',
+        id: 'part-6',
+        data: { name: 'get_weather', input: { city: 'SF' }, output: 62, status: 'ok' },
+      },
+      {
+        type: 'data-agent-action',
+        id: 'part-7',
+        data: { name: 'manage_todos', summary: 'Updated todos', data: { count: 3 } },
+      },
+    ])
+  })
+
+  test('serializes part timestamps and preserves the full metadata', () => {
+    const message = assistantMessage({
+      finishReason: 'stop',
+      usage: usage(42),
+      parts: [{ type: 'bash', command: 'ls', startedAt: createdAt, finishedAt: updatedAt }],
+    })
+
+    const uiMessage = toUIMessage(message)
+
+    expect(uiMessage.parts).toEqual([
+      {
+        type: 'data-bash',
+        id: 'part-0',
+        data: {
+          command: 'ls',
+          startedAt: '2026-01-01T00:00:00.000Z',
+          finishedAt: '2026-01-01T00:00:05.000Z',
+        },
+      },
+    ])
+    expect(uiMessage.metadata).toEqual({
+      ...serializedAssistantMetadata,
+      finishReason: 'stop',
+      usage: usage(42),
+    })
+  })
+
+  test('excludes role, content, and parts from metadata', () => {
+    const metadata = toUIMessage(assistantMessage({ content: 'Done' })).metadata
+
+    expect(metadata).not.toContainKeys(['role', 'content', 'parts'])
+  })
+
+  test('prepends attachments as file parts', () => {
+    const message = userMessage({
+      attachments: [
+        { url: 'https://example.com/logo.png', contentType: 'image/png', name: 'logo.png' },
+        { url: 'https://example.com/data' },
+      ],
+      parts: [{ type: 'text', text: 'Use this logo' }],
+    })
+
+    expect(toUIMessage(message).parts).toEqual([
+      {
+        type: 'file',
+        url: 'https://example.com/logo.png',
+        mediaType: 'image/png',
+        filename: 'logo.png',
+      },
+      {
+        type: 'file',
+        url: 'https://example.com/data',
+        mediaType: 'application/octet-stream',
+        filename: undefined,
+      },
+      { type: 'text', text: 'Use this logo', state: 'done' },
+    ])
+  })
+
+  test('keeps data part ids aligned with the original part index', () => {
+    const message = userMessage({
+      attachments: [{ url: 'https://example.com/a.png', contentType: 'image/png' }],
+      parts: [
+        { type: 'text', text: 'hi' },
+        { type: 'bash', command: 'ls' },
+      ],
+    })
+
+    const dataPart = toUIMessage(message).parts.at(-1)
+
+    expect(dataPart).toMatchObject({ type: 'data-bash', id: 'part-1' })
+  })
+
+  test('converts a message with no parts and no attachments', () => {
+    expect(toUIMessage(assistantMessage()).parts).toEqual([])
+  })
+})
+
+describe('toUIMessages', () => {
+  test('orders newest-first message lists chronologically', () => {
+    const first = userMessage({ id: 'msg_1', createdAt: new Date('2026-01-01T00:00:00.000Z') })
+    const second = assistantMessage({
+      id: 'msg_2',
+      createdAt: new Date('2026-01-01T00:00:10.000Z'),
+    })
+    const third = userMessage({ id: 'msg_3', createdAt: new Date('2026-01-01T00:00:20.000Z') })
+
+    const ids = toUIMessages([third, second, first]).map((message) => message.id)
+
+    expect(ids).toEqual(['msg_1', 'msg_2', 'msg_3'])
+  })
+
+  test('keeps chronological input chronological', () => {
+    const first = userMessage({ id: 'msg_1', createdAt: new Date('2026-01-01T00:00:00.000Z') })
+    const second = assistantMessage({
+      id: 'msg_2',
+      createdAt: new Date('2026-01-01T00:00:10.000Z'),
+    })
+
+    expect(toUIMessages([first, second]).map((message) => message.id)).toEqual(['msg_1', 'msg_2'])
+  })
+
+  test('places user messages before assistant messages on identical timestamps', () => {
+    const prompt = userMessage({ id: 'msg_1' })
+    const reply = assistantMessage({ id: 'msg_2' })
+
+    expect(toUIMessages([reply, prompt]).map((message) => message.id)).toEqual(['msg_1', 'msg_2'])
+    expect(toUIMessages([prompt, reply]).map((message) => message.id)).toEqual(['msg_1', 'msg_2'])
+  })
+
+  test('does not mutate the input', () => {
+    const newest = assistantMessage({ id: 'msg_2' })
+    const oldest = userMessage({
+      id: 'msg_1',
+      createdAt: new Date('2025-12-31T00:00:00.000Z'),
+    })
+    const input = [newest, oldest]
+
+    toUIMessages(input)
+
+    expect(input.map((message) => message.id)).toEqual(['msg_2', 'msg_1'])
+  })
+
+  test('returns an empty array for an empty list', () => {
+    expect(toUIMessages([])).toEqual([])
+  })
+})
+
+describe('fromUIMessage', () => {
+  test('extracts the message text', () => {
+    expect(
+      fromUIMessage({
+        id: 'msg_1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Build me a landing page' }],
+      }),
+    ).toEqual({ message: 'Build me a landing page' })
+  })
+
+  test('joins multiple text parts with blank lines', () => {
+    expect(
+      fromUIMessage({
+        id: 'msg_1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'Hello' },
+          { type: 'text', text: 'world' },
+        ],
+      }),
+    ).toEqual({ message: 'Hello\n\nworld' })
+  })
+
+  test('maps file parts to attachments', () => {
+    expect(
+      fromUIMessage({
+        id: 'msg_1',
+        role: 'user',
+        parts: [
+          { type: 'file', url: 'https://example.com/logo.png', mediaType: 'image/png' },
+          { type: 'text', text: 'Use this logo' },
+        ],
+      }),
+    ).toEqual({
+      message: 'Use this logo',
+      attachments: [{ url: 'https://example.com/logo.png' }],
+    })
+  })
+
+  test('ignores reasoning and data parts', () => {
+    const message = toUIMessage(
+      assistantMessage({
+        parts: [
+          { type: 'thinking', text: 'hmm' },
+          { type: 'bash', command: 'ls' },
+          { type: 'text', text: 'Done' },
+        ],
+      }),
+    )
+
+    expect(fromUIMessage(message)).toEqual({ message: 'Done' })
+  })
+
+  test('round-trips a converted v0 user message', () => {
+    const message = userMessage({
+      attachments: [{ url: 'https://example.com/logo.png', contentType: 'image/png' }],
+      parts: [{ type: 'text', text: 'Make it pop' }],
+    })
+
+    expect(fromUIMessage(toUIMessage(message))).toEqual({
+      message: 'Make it pop',
+      attachments: [{ url: 'https://example.com/logo.png' }],
+    })
+  })
+
+  test('returns an empty message for a message without text parts', () => {
+    expect(fromUIMessage({ id: 'msg_1', role: 'user', parts: [] })).toEqual({ message: '' })
+  })
+
+  test('accepts parameters for v0.messages.send and v0.chats.create', () => {
+    const parameters = fromUIMessage({
+      id: 'msg_1',
+      role: 'user',
+      parts: [{ type: 'text', text: 'hi' }],
+    })
+
+    const sendParameters: Parameters<
+      typeof import('../src/generated/sdk.gen').Messages.prototype.send
+    >[0] = { chatId: 'chat_1', ...parameters }
+    const createParameters: Parameters<
+      typeof import('../src/generated/sdk.gen').Chats.prototype.create
+    >[0] = parameters
+
+    expect(sendParameters.message).toBe('hi')
+    expect(createParameters.message).toBe('hi')
+  })
+})
+
+describe('type derivation', () => {
+  test('list responses are structurally assignable to Message', () => {
+    const fromList: import('../src/generated/types.gen').MessageListResponse['messages'] = []
+    const messages: Message[] = fromList
+
+    expect(toUIMessages(messages)).toEqual([])
+  })
+})

--- a/packages/v0-sdk/tests/use-v0-chat.test.tsx
+++ b/packages/v0-sdk/tests/use-v0-chat.test.tsx
@@ -1,0 +1,330 @@
+import { describe, expect, test } from 'bun:test'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { toUIMessages } from '../src/ai-sdk'
+import type { V0UIMessageChunk } from '../src/ai-sdk'
+import { useV0Chat } from '../src/react'
+import type { UseV0ChatHelpers, UseV0ChatOptions } from '../src/react'
+import { assistantMessage, userMessage } from './helpers'
+
+interface RecordedRequest {
+  url: string
+  method: string
+  body: unknown
+}
+
+function sseBody(chunks: V0UIMessageChunk[]): string {
+  return `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`
+}
+
+function sseResponse(chunks: V0UIMessageChunk[]): Response {
+  return new Response(sseBody(chunks), {
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+function assistantResponse(chatId: string, messageId: string, text: string): Response {
+  return sseResponse([
+    { type: 'start', messageId, messageMetadata: { id: messageId, chatId } },
+    { type: 'text-start', id: 'text-0' },
+    { type: 'text-delta', id: 'text-0', delta: text },
+    { type: 'text-end', id: 'text-0' },
+    { type: 'finish', messageMetadata: { id: messageId, chatId } },
+  ])
+}
+
+function createFetchRecorder(respond: (request: RecordedRequest) => Response) {
+  const requests: RecordedRequest[] = []
+
+  const fetch: NonNullable<UseV0ChatOptions['fetch']> = Object.assign(
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const request: RecordedRequest = {
+        url: String(input),
+        method: init?.method ?? 'GET',
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      }
+      requests.push(request)
+      return respond(request)
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+
+  return { fetch, requests }
+}
+
+async function renderV0Chat(options: UseV0ChatOptions) {
+  const result: { current: UseV0ChatHelpers } = { current: undefined as never }
+
+  function Harness() {
+    result.current = useV0Chat(options)
+    return null
+  }
+
+  const root = createRoot(document.createElement('div'))
+  await act(async () => {
+    root.render(<Harness />)
+  })
+
+  return {
+    result,
+    unmount: () => act(() => root.unmount()),
+  }
+}
+
+describe('useV0Chat', () => {
+  test('sends the v0 request body for a new chat', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_1', 'msg_2', 'Hello!'),
+    )
+    const { result } = await renderV0Chat({ fetch })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Build me a landing page' })
+    })
+
+    expect(requests).toEqual([
+      {
+        url: '/api/chat',
+        method: 'POST',
+        body: { message: 'Build me a landing page' },
+      },
+    ])
+  })
+
+  test('streams the assistant message into typed messages', async () => {
+    const { fetch } = createFetchRecorder(() => assistantResponse('chat_1', 'msg_2', 'Hello!'))
+    const { result } = await renderV0Chat({ fetch })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Hi' })
+    })
+
+    const assistant = result.current.messages.at(-1)
+
+    expect(result.current.messages).toHaveLength(2)
+    expect(assistant?.id).toBe('msg_2')
+    expect(assistant?.metadata?.chatId).toBe('chat_1')
+    expect(assistant?.parts).toEqual([{ type: 'text', text: 'Hello!', state: 'done' }])
+  })
+
+  test('derives the chatId from streamed metadata and sends it on follow-ups', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_1', 'msg_2', 'Hello!'),
+    )
+    const { result } = await renderV0Chat({ fetch })
+
+    expect(result.current.chatId).toBeUndefined()
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'First' })
+    })
+
+    expect(result.current.chatId).toBe('chat_1')
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Second' })
+    })
+
+    expect(requests[1]?.body).toEqual({ chatId: 'chat_1', message: 'Second' })
+  })
+
+  test('uses the chatId option as the useChat id and request chatId', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_9', 'msg_2', 'Hi!'),
+    )
+    const { result } = await renderV0Chat({ fetch, chatId: 'chat_9' })
+
+    expect(result.current.id).toBe('chat_9')
+    expect(result.current.chatId).toBe('chat_9')
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Continue' })
+    })
+
+    expect(requests[0]?.body).toEqual({ chatId: 'chat_9', message: 'Continue' })
+  })
+
+  test('derives the chatId from initial messages', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_7', 'msg_3', 'More!'),
+    )
+    const initialMessages = toUIMessages([
+      userMessage({ chatId: 'chat_7', parts: [{ type: 'text', text: 'Start' }] }),
+      assistantMessage({ chatId: 'chat_7', parts: [{ type: 'text', text: 'Started' }] }),
+    ])
+    const { result } = await renderV0Chat({ fetch, messages: initialMessages })
+
+    expect(result.current.chatId).toBe('chat_7')
+    expect(result.current.messages).toHaveLength(2)
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Keep going' })
+    })
+
+    expect(requests[0]?.body).toEqual({ chatId: 'chat_7', message: 'Keep going' })
+  })
+
+  test('sends file parts as v0 attachments', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_1', 'msg_2', 'Nice logo'),
+    )
+    const { result } = await renderV0Chat({ fetch })
+
+    await act(async () => {
+      await result.current.sendMessage({
+        text: 'Use this logo',
+        files: [{ type: 'file', url: 'https://example.com/logo.png', mediaType: 'image/png' }],
+      })
+    })
+
+    expect(requests[0]?.body).toEqual({
+      message: 'Use this logo',
+      attachments: [{ url: 'https://example.com/logo.png' }],
+    })
+  })
+
+  test('merges custom body fields into the request', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_1', 'msg_2', 'Hello!'),
+    )
+    const { result } = await renderV0Chat({ fetch, body: { systemPrompt: 'Be brief' } })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Hi' })
+    })
+
+    expect(requests[0]?.body).toEqual({ systemPrompt: 'Be brief', message: 'Hi' })
+  })
+
+  test('posts to a custom api path', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_1', 'msg_2', 'Hello!'),
+    )
+    const { result } = await renderV0Chat({ fetch, api: '/api/v0-chat' })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Hi' })
+    })
+
+    expect(requests[0]?.url).toBe('/api/v0-chat')
+  })
+
+  test('regenerate resends the last user message', async () => {
+    const { fetch, requests } = createFetchRecorder(() =>
+      assistantResponse('chat_1', 'msg_2', 'Hello again!'),
+    )
+    const { result } = await renderV0Chat({ fetch })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Original prompt' })
+    })
+    await act(async () => {
+      await result.current.regenerate()
+    })
+
+    expect(requests[1]?.body).toEqual({ chatId: 'chat_1', message: 'Original prompt' })
+  })
+
+  test('resumes an in-flight generation via the chatId query parameter', async () => {
+    const { fetch, requests } = createFetchRecorder((request) =>
+      request.method === 'GET'
+        ? assistantResponse('chat_5', 'msg_8', 'Still going')
+        : new Response(null, { status: 204 }),
+    )
+    const { result } = await renderV0Chat({ fetch, chatId: 'chat_5', resume: true })
+
+    await act(async () => {
+      await Bun.sleep(10)
+    })
+
+    expect(requests).toEqual([{ url: '/api/chat?chatId=chat_5', method: 'GET', body: undefined }])
+    expect(result.current.messages.at(-1)?.parts).toEqual([
+      { type: 'text', text: 'Still going', state: 'done' },
+    ])
+  })
+
+  test('handles 204 responses for resume when nothing is streaming', async () => {
+    const { fetch, requests } = createFetchRecorder(() => new Response(null, { status: 204 }))
+    const { result } = await renderV0Chat({ fetch, chatId: 'chat_5', resume: true })
+
+    await act(async () => {
+      await Bun.sleep(10)
+    })
+
+    expect(requests[0]?.method).toBe('GET')
+    expect(result.current.error).toBeUndefined()
+    expect(result.current.messages).toEqual([])
+  })
+
+  test('forwards transient chat data to onData with full typing', async () => {
+    const titles: Array<string | undefined> = []
+    const { fetch } = createFetchRecorder(() =>
+      sseResponse([
+        { type: 'start', messageId: 'msg_2', messageMetadata: { id: 'msg_2', chatId: 'chat_1' } },
+        {
+          type: 'data-chat',
+          id: 'chat',
+          transient: true,
+          data: {
+            id: 'chat_1',
+            privacy: 'private',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            authorId: 'user_1',
+            metadata: {},
+            writePermission: true,
+            title: 'Landing page',
+          },
+        },
+        { type: 'finish' },
+      ]),
+    )
+    const { result } = await renderV0Chat({
+      fetch,
+      onData: (part) => {
+        if (part.type === 'data-chat') {
+          titles.push(part.data.title)
+        }
+      },
+    })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Hi' })
+    })
+
+    expect(titles).toEqual(['Landing page'])
+  })
+
+  test('does not persist transient chat data on the message', async () => {
+    const { fetch } = createFetchRecorder(() =>
+      sseResponse([
+        { type: 'start', messageId: 'msg_2', messageMetadata: { id: 'msg_2', chatId: 'chat_1' } },
+        {
+          type: 'data-chat',
+          id: 'chat',
+          transient: true,
+          data: {
+            id: 'chat_1',
+            privacy: 'private',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            authorId: 'user_1',
+            metadata: {},
+            writePermission: true,
+          },
+        },
+        { type: 'text-start', id: 'text-0' },
+        { type: 'text-delta', id: 'text-0', delta: 'Hi!' },
+        { type: 'text-end', id: 'text-0' },
+        { type: 'finish' },
+      ]),
+    )
+    const { result } = await renderV0Chat({ fetch })
+
+    await act(async () => {
+      await result.current.sendMessage({ text: 'Hi' })
+    })
+
+    expect(result.current.messages.at(-1)?.parts).toEqual([
+      { type: 'text', text: 'Hi!', state: 'done' },
+    ])
+  })
+})

--- a/packages/v0-sdk/tsconfig.json
+++ b/packages/v0-sdk/tsconfig.json
@@ -7,7 +7,9 @@
     "moduleResolution": "bundler",
     "exactOptionalPropertyTypes": false,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "jsx": "react-jsx",
+    "types": ["bun"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts", "tests/**/*.tsx"]
 }

--- a/packages/v0-sdk/tsdown.config.ts
+++ b/packages/v0-sdk/tsdown.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'ai-sdk': 'src/ai-sdk/index.ts',
+    react: 'src/react/index.ts',
+  },
   format: ['cjs', 'esm'],
   exports: true,
   dts: {


### PR DESCRIPTION
Additive AI SDK v7 compatibility for the `v0` SDK: two new entry points, `v0/ai-sdk` and `v0/react`, with optional peer deps on `ai`, `@ai-sdk/react`, and `react`. No changes to the existing API.

## Server

```ts
// app/api/chat/route.ts
import { v0 } from 'v0'
import { toUIMessageStreamResponse } from 'v0/ai-sdk'

export async function POST(request: Request) {
  const { chatId, message, attachments } = await request.json()

  return toUIMessageStreamResponse(
    chatId
      ? await v0.messages.sendStream({ chatId, message, attachments })
      : await v0.chats.createStream({ message, attachments }),
  )
}

// stream resumption
export async function GET(request: Request) {
  const chatId = new URL(request.url).searchParams.get('chatId')
  if (!chatId) return new Response(null, { status: 204 })

  try {
    return toUIMessageStreamResponse(await v0.chats.resume({ chatId }))
  } catch {
    return new Response(null, { status: 204 })
  }
}
```

## Client

```tsx
'use client'

import { useV0Chat } from 'v0/react'

const { messages, sendMessage, status, chatId } = useV0Chat()

// or, with an existing chat + resumption of in-flight generations
useV0Chat({ chatId, messages, resume: true })
```

Prefer the plain hook? Same route handler:

```tsx
import { useChat } from '@ai-sdk/react'
import type { V0UIMessage } from 'v0/ai-sdk'

useChat<V0UIMessage>() // just works
```

## Fully typed messages, derived from the SDK

`V0UIMessage` derives entirely from the existing `Message` type. `text`/`thinking` map to the AI SDK's native `text`/`reasoning` parts; every other v0 part becomes a typed `data-*` part; the remaining `Message` fields are the metadata.

```tsx
{message.parts.map((part, index) => {
  switch (part.type) {
    case 'text':
      return <p key={index}>{part.text}</p>
    case 'reasoning':
      return <em key={index}>{part.text}</em>
    case 'data-file-edit':
      // part.data.operation: 'create' | 'update' | 'delete' | 'rename' | 'patch'
      return <code key={index}>{`${part.data.operation} ${part.data.path}`}</code>
    case 'data-bash':
      return <pre key={index}>{`$ ${part.data.command}`}</pre>
    default:
      return null
  }
})}

message.metadata?.chatId
message.metadata?.usage?.creditsCost.total
```

## Loading history

```ts
import { toUIMessages } from 'v0/ai-sdk'

const response = await v0.messages.list({ chatId, limit: 100 })
const messages = toUIMessages(response.data.messages) // pass to useV0Chat({ chatId, messages })
```

---

Also exports `toUIMessageStream` (raw chunk stream), `toUIMessage`, and `fromUIMessage` for custom setups. 55 tests cover the converters, the stream protocol adapter (driven through the SDK's real jsondiffpatch deltas), and `useV0Chat` rendered against a recorded `fetch`.
