### PR TITLE
fix: DOM text reinterpreted validate restored attachment URLs in createImageAttachmentFromStored

### DIFF
--- a/examples/v0-clone/components/ai-elements/prompt-input.tsx
+++ b/examples/v0-clone/components/ai-elements/prompt-input.tsx
@@ -103,6 +103,18 @@ export const clearPromptFromStorage = () => {
   }
 }
 
+const sanitizeImageSource = (value: string): string => {
+  if (!value) return ''
+
+  // Allow only image data URLs or blob URLs for previews.
+  if (value.startsWith('blob:')) return value
+  if (/^data:image\/[a-zA-Z0-9.+-]+;base64,[a-zA-Z0-9+/=]+$/.test(value)) {
+    return value
+  }
+
+  return ''
+}
+
 export const createImageAttachmentFromStored = (
   stored: StoredPromptData['attachments'][0],
 ): ImageAttachment => {
@@ -111,8 +123,8 @@ export const createImageAttachmentFromStored = (
   return {
     id: stored.id,
     file: mockFile,
-    dataUrl: stored.dataUrl,
-    preview: stored.preview,
+    dataUrl: sanitizeImageSource(stored.dataUrl),
+    preview: sanitizeImageSource(stored.preview),
   }
 }
 

--- a/examples/v0-clone/components/ai-elements/web-preview.tsx
+++ b/examples/v0-clone/components/ai-elements/web-preview.tsx
@@ -162,13 +162,25 @@ export const WebPreviewBody = ({
   ...props
 }: WebPreviewBodyProps) => {
   const { url } = useWebPreview()
+  const rawSrc = src ?? url
+  const safeSrc = (() => {
+    if (!rawSrc) return undefined
+    try {
+      const parsed = new URL(rawSrc)
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+        ? parsed.toString()
+        : undefined
+    } catch {
+      return undefined
+    }
+  })()
 
   return (
     <div className="flex-1">
       <iframe
         className={cn('size-full', className)}
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-        src={(src ?? url) || undefined}
+        src={safeSrc}
         title="Preview"
         {...props}
       />


### PR DESCRIPTION
Extracting text from a DOM node and interpreting it as HTML can lead to a javascript/code injection vulnerability. A webpage with this vulnerability reads text from the DOM, and afterwards adds the text as HTML to the DOM. Using text from the DOM as HTML effectively unescapes the text, and thereby invalidates any escaping done on the text. If an attacker is able to control the safe sanitized text, then this vulnerability can be exploited to perform a javascript/code injection attack.


Use strict validation/normalization for `preview` and `dataUrl` so only safe image sources are accepted. The best minimal fix is to validate restored attachment URLs in `createImageAttachmentFromStored` and reject anything that is not an image `data:` URL or safe `blob:` URL. This preserves current functionality (image previews still work for normal uploads and restored sessions) while blocking unexpected schemes/content.

In `examples/v0-clone/components/ai-elements/prompt-input.tsx`:
- Add a small helper (near storage utilities) to validate preview URLs:
  - allow `data:image/...;base64,...`
  - allow `blob:` URLs
  - otherwise return empty string (or fallback).
- Update `createImageAttachmentFromStored` to pass `stored.dataUrl` and `stored.preview` through the validator before assigning them.


