### PR TITLE
Improve React SDK ergonomics

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -123,4 +123,38 @@ export function AIChat({ history }: { history: MessagesListResponse['messages'] 
 
 `toV0UIMessages` maps persisted newest-first v0 history to chronological AI SDK messages. Text, reasoning, files, tools, rich v0 data parts, metadata, and resumable state are preserved. To stop generation, import `useStopMessage` from `@v0-sdk/react/swr`, call it for the active assistant on the server, then call the AI SDK's `chat.stop()` locally.
 
+When a newly created chat should immediately navigate to a different page, stop
+the current transport directly from `onChatCreated`:
+
+```tsx
+const transport = new V0Transport({
+  urls,
+  onChatCreated(chatId, { stop }) {
+    stop()
+    router.push(`/chats/${chatId}`)
+  },
+})
+```
+
+## Pending tasks
+
+Use `getPendingV0Task` to find the latest questions, plan, integration request,
+or permission request carried by a v0 UI message:
+
+```tsx
+import { getPendingV0Task } from '@v0-sdk/react'
+
+const pendingTask = getPendingV0Task(chat.messages.at(-1)!)
+```
+
+## Cache revalidation
+
+Related mounted queries are revalidated after successful mutations:
+
+- `useDeleteChat` revalidates chat lists.
+- `useRestoreMessage` and `useUpdateChatFiles` revalidate messages and files.
+- `useUpdateChat` revalidates the chat and chat lists.
+
+Pass `revalidate: false` to the mutation configuration to opt out.
+
 See [`examples/react-chat`](../../examples/react-chat) for a complete one-page app and authenticated proxy routes.

--- a/packages/react/src/chat/chunks.ts
+++ b/packages/react/src/chat/chunks.ts
@@ -149,7 +149,11 @@ export function v0StreamToUIMessageStream(
   result: V0StreamResult,
   options: {
     seed?: Message
-    onUpdate?: (update: V0StreamUpdate | V0StreamFinal) => void
+    /**
+     * Return `false` to stop forwarding the stream without surfacing an error
+     * to the consumer.
+     */
+    onUpdate?: (update: V0StreamUpdate | V0StreamFinal) => boolean | void
     onClose?: () => void
     abort?: (reason?: unknown) => void
   } = {},
@@ -171,13 +175,25 @@ export function v0StreamToUIMessageStream(
         while (!canceled) {
           const next = await iterator.next()
           if (next.done) break
-          options.onUpdate?.(next.value)
+          if (options.onUpdate?.(next.value) === false) {
+            canceled = true
+            options.abort?.()
+            await iterator.return?.()
+            controller.close()
+            return
+          }
           for (const chunk of reducer.push(next.value)) controller.enqueue(chunk)
         }
 
         if (!canceled) {
           const final = await result.final
-          options.onUpdate?.(final)
+          if (options.onUpdate?.(final) === false) {
+            canceled = true
+            options.abort?.()
+            await iterator.return?.()
+            controller.close()
+            return
+          }
           for (const chunk of reducer.push(final, true)) controller.enqueue(chunk)
           controller.close()
         }

--- a/packages/react/src/chat/index.ts
+++ b/packages/react/src/chat/index.ts
@@ -12,5 +12,12 @@ export {
   toV0UIMessages,
 } from './messages'
 export type { Serialized, V0UIDataTypes, V0UIMessage, V0UIMessageMetadata } from './messages'
+export { getPendingV0Task } from './tasks'
+export type { V0PendingTask } from './tasks'
 export { V0Transport } from './transport'
-export type { V0TransportChatUrl, V0TransportOptions, V0TransportUrls } from './transport'
+export type {
+  V0TransportChatUrl,
+  V0TransportOptions,
+  V0TransportStreamControls,
+  V0TransportUrls,
+} from './transport'

--- a/packages/react/src/chat/tasks.ts
+++ b/packages/react/src/chat/tasks.ts
@@ -1,0 +1,55 @@
+import type { V0UIMessage } from './messages'
+
+type MessagePart = V0UIMessage['parts'][number]
+type AgentActionPart = Extract<MessagePart, { type: 'data-v0-agent-action' }>
+type AgentActionData = NonNullable<AgentActionPart['data']['data']>
+type QuestionsData = Extract<AgentActionData, { questions: unknown }>
+type PlanData = Extract<AgentActionData, { plan: unknown }>
+type IntegrationData = Extract<AgentActionData, { requestedIntegrations: unknown }>
+type ToolCallPart = Extract<MessagePart, { type: 'data-v0-tool-call' }>
+type Permission = NonNullable<ToolCallPart['data']['suggestedPermissions']>[number]
+
+export type V0PendingTask =
+  | { type: 'questions'; data: QuestionsData }
+  | { type: 'plan'; data: PlanData }
+  | { type: 'integration'; data: IntegrationData }
+  | { type: 'permissions'; permissions: Permission[] }
+
+/** Returns the most recent user-resolvable task carried by a v0 message. */
+export function getPendingV0Task(message: V0UIMessage): V0PendingTask | null {
+  for (let index = message.parts.length - 1; index >= 0; index -= 1) {
+    const part = message.parts[index]
+    if (!part) continue
+
+    if (part.type === 'data-v0-tool-call') {
+      const toolCall = part as ToolCallPart
+      if (!toolCall.data.suggestedPermissions?.length) continue
+
+      return {
+        type: 'permissions',
+        permissions: toolCall.data.suggestedPermissions,
+      }
+    }
+
+    if (part.type !== 'data-v0-agent-action') continue
+    const action = part as AgentActionPart
+    if (!action.data.data) continue
+
+    if (action.data.name === 'ask_user_questions' && 'questions' in action.data.data) {
+      return { type: 'questions', data: action.data.data }
+    }
+
+    if (action.data.name === 'exit_plan_mode' && 'plan' in action.data.data) {
+      return { type: 'plan', data: action.data.data }
+    }
+
+    if (
+      action.data.name === 'get_or_request_integration' &&
+      'requestedIntegrations' in action.data.data
+    ) {
+      return { type: 'integration', data: action.data.data }
+    }
+  }
+
+  return null
+}

--- a/packages/react/src/chat/transport.ts
+++ b/packages/react/src/chat/transport.ts
@@ -21,6 +21,11 @@ export interface V0TransportUrls {
   resume: V0TransportChatUrl
 }
 
+export interface V0TransportStreamControls {
+  /** Stops the active transport stream without reporting an error to `useChat`. */
+  stop: () => void
+}
+
 export interface V0TransportOptions {
   urls: V0TransportUrls
   chatId?: string
@@ -29,7 +34,7 @@ export interface V0TransportOptions {
   create?: Omit<ChatsCreateStreamData['body'], 'message' | 'attachments'>
   send?: Omit<MessagesSendStreamData['body'], 'message' | 'attachments'>
   request?: V0RequestOptions
-  onChatCreated?: (chatId: string) => void
+  onChatCreated?: (chatId: string, controls: V0TransportStreamControls) => void
 }
 
 const streamOperation: V0Operation<Response> = {
@@ -149,11 +154,18 @@ export class V0Transport implements ChatTransport<V0UIMessage> {
     }
   }
 
-  private captureChatId(update: V0StreamUpdate | V0StreamFinal) {
+  private captureChatId(update: V0StreamUpdate | V0StreamFinal): boolean {
     const chatId = update.chat?.id ?? update.message?.chatId
-    if (!chatId || chatId === this.currentChatId) return
+    if (!chatId || chatId === this.currentChatId) return true
+
     this.currentChatId = chatId
-    this.options.onChatCreated?.(chatId)
+    let stopped = false
+    this.options.onChatCreated?.(chatId, {
+      stop: () => {
+        stopped = true
+      },
+    })
+    return !stopped
   }
 }
 

--- a/packages/react/src/generated/swr.ts
+++ b/packages/react/src/generated/swr.ts
@@ -305,6 +305,7 @@ const deleteChatOperation: V0Operation<ChatsDeleteResponse> = {
   id: 'chats.delete',
   method: 'DELETE',
   response: 'json',
+  invalidates: ['chats.list'],
 }
 
 export function useDeleteChat(
@@ -447,6 +448,7 @@ const restoreMessageOperation: V0Operation<ChatsRestoreMessageResponse> = {
   method: 'POST',
   response: 'json',
   transform: chatsRestoreMessageResponseTransformer,
+  invalidates: ['chats.getFiles', 'messages.list'],
 }
 
 export type RestoreMessageInput = ChatsRestoreMessageData['body']
@@ -479,6 +481,7 @@ const updateChatOperation: V0Operation<ChatsUpdateResponse> = {
   method: 'PATCH',
   response: 'json',
   transform: chatsUpdateResponseTransformer,
+  invalidates: ['chats.get', 'chats.list'],
 }
 
 export type UpdateChatInput = ChatsUpdateData['body']
@@ -498,6 +501,7 @@ const updateChatFilesOperation: V0Operation<ChatsUpdateFilesResponse> = {
   method: 'PATCH',
   response: 'json',
   transform: chatsUpdateFilesResponseTransformer,
+  invalidates: ['chats.getFiles', 'messages.list'],
 }
 
 export type UpdateChatFilesInput = ChatsUpdateFilesData['body']

--- a/packages/react/src/request.ts
+++ b/packages/react/src/request.ts
@@ -16,6 +16,8 @@ export interface V0Operation<Data> {
   method: V0HttpMethod
   response: V0ResponseKind
   transform?: V0ResponseTransformer<Data>
+  /** Query operation IDs revalidated after this mutation succeeds. */
+  invalidates?: readonly string[]
 }
 
 /** HTTP error returned by the application's v0 proxy. */

--- a/packages/react/src/scripts/generate.ts
+++ b/packages/react/src/scripts/generate.ts
@@ -36,6 +36,7 @@ type Operation = {
   hasBody: boolean
   responseKind: 'json' | 'stream' | 'blob'
   paginated: boolean
+  invalidates?: readonly V0SdkOperationId[]
   transformer?: string
 }
 
@@ -79,6 +80,13 @@ const semanticNames = {
   'webhooks.update': 'useUpdateWebhook',
   'webhooks.delete': 'useDeleteWebhook',
 } as const satisfies Record<V0SdkOperationId, string>
+
+const mutationInvalidations: Partial<Record<V0SdkOperationId, readonly V0SdkOperationId[]>> = {
+  'chats.delete': ['chats.list'],
+  'chats.restoreMessage': ['chats.getFiles', 'messages.list'],
+  'chats.update': ['chats.get', 'chats.list'],
+  'chats.updateFiles': ['chats.getFiles', 'messages.list'],
+}
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(dirname, '../../../..')
@@ -147,6 +155,7 @@ function collectOperations(spec: OpenApiDocument, availableTransformers: Set<str
           : 'json'
       const typePrefix = toTypePrefix(operationId)
       const transformer = `${lowerFirst(typePrefix)}ResponseTransformer`
+      const invalidates = mutationInvalidations[operationId]
 
       operations.push({
         operationId,
@@ -159,6 +168,7 @@ function collectOperations(spec: OpenApiDocument, availableTransformers: Set<str
         paginated: parameters.some(
           (parameter) => parameter.in === 'query' && parameter.name === 'cursor',
         ),
+        ...(invalidates ? { invalidates } : {}),
         ...(availableTransformers.has(transformer) ? { transformer } : {}),
       })
     }
@@ -222,7 +232,7 @@ function renderOperation(operation: Operation): string {
 
 function renderOperationDefinition(operation: Operation): string {
   const responseType = getResponseType(operation)
-  return `const ${getOperationName(operation)}: V0Operation<${responseType}> = {\n  id: '${operation.operationId}',\n  method: '${operation.httpMethod}',\n  response: '${operation.responseKind}'${operation.transformer ? `,\n  transform: ${operation.transformer}` : ''},\n}`
+  return `const ${getOperationName(operation)}: V0Operation<${responseType}> = {\n  id: '${operation.operationId}',\n  method: '${operation.httpMethod}',\n  response: '${operation.responseKind}'${operation.transformer ? `,\n  transform: ${operation.transformer}` : ''}${operation.invalidates ? `,\n  invalidates: [${operation.invalidates.map((id) => `'${id}'`).join(', ')}]` : ''},\n}`
 }
 
 function renderQuery(operation: Operation): string {

--- a/packages/react/src/swr-runtime.ts
+++ b/packages/react/src/swr-runtime.ts
@@ -1,4 +1,4 @@
-import useSWR, { type Key, type SWRConfiguration } from 'swr'
+import useSWR, { type Key, type SWRConfiguration, useSWRConfig } from 'swr'
 import useSWRInfinite, {
   type SWRInfiniteConfiguration,
   type SWRInfiniteKeyLoader,
@@ -74,13 +74,21 @@ export function useV0Mutation<Data, ErrorBody, Input>(
   url: string,
   configuration: V0MutationConfiguration<Data, ErrorBody, Input> = {},
 ) {
+  const { mutate } = useSWRConfig()
   const { request, ...swrConfiguration } = configuration
   const key = createV0Key(operation.id, url, null)
 
   return useSWRMutation<Data, V0ResponseError<ErrorBody>, Key, Input>(
     key,
-    (_key: Key, { arg }: { arg: Input }) =>
-      requestV0Operation<Data, ErrorBody>(url, operation, arg, request),
+    async (_key: Key, { arg }: { arg: Input }) => {
+      const data = await requestV0Operation<Data, ErrorBody>(url, operation, arg, request)
+
+      if (operation.invalidates?.length && swrConfiguration.revalidate !== false) {
+        await mutate((candidate) => isV0OperationKey(candidate, operation.invalidates!))
+      }
+
+      return data
+    },
     swrConfiguration,
   )
 }
@@ -106,9 +114,31 @@ export function useV0CursorQuery<Page, ErrorBody, Input extends object>(
     return createV0Key(operation.id, url, pageInput)
   }
 
-  return useSWRInfinite<Page, V0ResponseError<ErrorBody>>(
+  const result = useSWRInfinite<Page, V0ResponseError<ErrorBody>>(
     getKey,
     (key) => requestV0Operation<Page, ErrorBody>(url!, operation, key.at(-1), request),
     swrConfiguration,
+  )
+
+  // SWR's global key filters skip its internal infinite-query keys. Register a
+  // regular key whose revalidation delegates to the bound infinite mutation.
+  const invalidationKey =
+    url && input && enabled !== false ? (['v0-infinite', operation.id, url, input] as const) : null
+  useSWR(invalidationKey, () => result.mutate(), {
+    revalidateOnFocus: false,
+    revalidateOnMount: false,
+    revalidateOnReconnect: false,
+    shouldRetryOnError: false,
+  })
+
+  return result
+}
+
+function isV0OperationKey(key: unknown, operationIds: readonly string[]): boolean {
+  return (
+    Array.isArray(key) &&
+    (key[0] === 'v0' || key[0] === 'v0-infinite') &&
+    typeof key[1] === 'string' &&
+    operationIds.includes(key[1])
   )
 }


### PR DESCRIPTION
## Summary

- Let `onChatCreated` stop its active transport stream before navigating.
- Add `getPendingV0Task` for typed task discovery in v0 UI messages.
- Revalidate related SWR queries after successful chat mutations, including mounted infinite queries.

## Why

The v0 clone needed application-level refs, task parsing, and manual cache refreshes to integrate the React package. The package did not expose stream lifecycle controls or task discovery, and generated mutations did not know which mounted queries became stale.

## Impact

React consumers can remove that repeated integration code while retaining control over cache revalidation with `revalidate: false`.

## Verification

- `bun run typecheck`
- `bun test` (30 tests)
- `bun run build`
- `attw`
- `publint`
