### PR TITLE
Fix v0-clone build

### DIFF
--- a/examples/v0-clone/apps/preview-proxy/vercel.json
+++ b/examples/v0-clone/apps/preview-proxy/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "if [ -d ../../../../packages/v0-sdk ]; then cd ../../../..; else cd ../..; fi && bun install --frozen-lockfile",
+  "buildCommand": "if [ -d ../../../../packages/v0-sdk ]; then cd ../../../.. && bun --filter v0 build && bun --filter @v0-clone/preview-proxy build; else cd ../.. && bun --filter @v0-clone/preview-proxy build; fi"
+}

--- a/examples/v0-clone/apps/web/vercel.json
+++ b/examples/v0-clone/apps/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "if [ -d ../../../../packages/v0-sdk ]; then cd ../../../..; else cd ../..; fi && bun install --frozen-lockfile",
+  "buildCommand": "if [ -d ../../../../packages/v0-sdk ]; then cd ../../../.. && bun --filter v0 build && bun --filter @v0-sdk/react build && bun --filter @v0-clone/web build; else cd ../.. && bun --filter @v0-clone/web build; fi"
+}


### PR DESCRIPTION
We need to install from the root directory, because these projects are in a nested monorepo. Otherwise the install runs in `examples/v0-clone` only and doesn't include the SDK.