### PR TITLE
fix(v0-sdk): prevent fetchPreview host escape via string path

### DIFF
--- a/packages/v0-sdk/package.json
+++ b/packages/v0-sdk/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "generate": "openapi-ts",
     "build": "tsdown",
+    "test": "bun test",
     "typecheck": "tsc",
     "prepublishOnly": "bun run generate && bun run build"
   },

--- a/packages/v0-sdk/src/preview-proxy.test.ts
+++ b/packages/v0-sdk/src/preview-proxy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test'
+import { fetchPreview } from './preview-proxy'
+
+const PREVIEW_URL = 'https://legit-preview.example.test'
+const PREVIEW_TOKEN = 'SECRET-PREVIEW-TOKEN'
+
+function makePreview() {
+  return {
+    url: PREVIEW_URL,
+    token: PREVIEW_TOKEN,
+  } as Parameters<typeof fetchPreview>[0]['preview']
+}
+
+/**
+ * Runs `fetchPreview` with a spy fetch and reports the upstream URL the helper
+ * actually resolved to and the preview token it attached.
+ */
+async function runWithSpy(
+  path: string | string[],
+): Promise<{ host: string; url: string; token: string | null }> {
+  let sawUrl = ''
+  let sawToken: string | null = null
+  const spyFetch = (async (input: Request | string | URL, init?: RequestInit) => {
+    sawUrl = input instanceof URL ? input.toString() : String(input)
+    sawToken = new Headers(init?.headers).get('x-v0-preview-token')
+    return new Response('ok')
+  }) as unknown as typeof fetch
+
+  await fetchPreview({
+    request: new Request('https://my-app.example/api/v0-preview/chat123/anything'),
+    preview: makePreview(),
+    fallbackUrl: 'https://my-app.example/loading',
+    path,
+    fetch: spyFetch,
+  })
+
+  return { host: new URL(sawUrl).host, url: sawUrl, token: sawToken }
+}
+
+describe('fetchPreview path normalization', () => {
+  const previewHost = new URL(PREVIEW_URL).host
+
+  it('keeps a protocol-relative string path on the preview origin and does not leak the token', async () => {
+    const { host, token } = await runWithSpy('//attacker.example/steal')
+    expect(host).toBe(previewHost)
+    // The token only rode along because the request stayed on the preview host.
+    expect(token).toBe(PREVIEW_TOKEN)
+  })
+
+  it('neutralizes backslash and scheme-relative string paths', async () => {
+    const malicious = [
+      '/\\attacker.example/steal',
+      'https://attacker.example/steal',
+      '\\\\attacker.example/steal',
+    ]
+    for (const path of malicious) {
+      const { host } = await runWithSpy(path)
+      expect(host).toBe(previewHost)
+    }
+  })
+
+  it('forwards a normal string path unchanged on the preview origin', async () => {
+    const { host, url } = await runWithSpy('nested/route')
+    expect(host).toBe(previewHost)
+    expect(url).toBe(`${PREVIEW_URL}/nested/route`)
+  })
+
+  it('forwards array paths (encoded) on the preview origin', async () => {
+    const { host, url } = await runWithSpy(['//attacker.example', 'steal'])
+    expect(host).toBe(previewHost)
+    expect(url.startsWith(`${PREVIEW_URL}/`)).toBe(true)
+  })
+})

--- a/packages/v0-sdk/src/preview-proxy.ts
+++ b/packages/v0-sdk/src/preview-proxy.ts
@@ -111,6 +111,16 @@ export async function fetchPreview({
   const incomingUrl = new URL(request.url)
 
   const upstreamUrl = new URL(normalizePreviewPath(path), preview.url)
+
+  // Defense-in-depth: the forwarded path must never leave the preview origin.
+  // `normalizePreviewPath` already neutralizes protocol- and scheme-relative
+  // strings, but we also refuse outright if the resolved URL somehow lands on a
+  // different origin, so the `x-v0-preview-token` is never attached to a
+  // cross-host request.
+  if (upstreamUrl.origin !== new URL(preview.url).origin) {
+    throw new Error('Preview path resolved to a different origin than the preview URL.')
+  }
+
   upstreamUrl.search = incomingUrl.search
 
   const headers = getPreviewRequestHeaders(request, preview.token)
@@ -178,7 +188,13 @@ function getPreviewResponseHeaders(response: Response) {
 
 function normalizePreviewPath(path: string | string[]) {
   if (typeof path === 'string') {
-    return path.startsWith('/') ? path : `/${path}`
+    // Collapse any leading whitespace, slashes, and backslashes before
+    // prepending a single slash. Without this, a caller-influenced string such
+    // as `//attacker/x`, `/\attacker/x`, or `https://attacker/x` would resolve
+    // against `preview.url` as a protocol- or scheme-relative URL pointing at a
+    // different origin, leaking `x-v0-preview-token` to that host. The result
+    // is always a single-origin-relative path.
+    return `/${path.replace(/^[\s/\\]+/, '')}`
   }
 
   return `/${path.map((segment) => encodeURIComponent(segment)).join('/')}`


### PR DESCRIPTION
## Summary

Neutralize a caller-influenced string `path` in `fetchPreview` so a forwarded preview request can never leave the preview origin and leak `x-v0-preview-token` to an attacker host.

## Problem

`fetchPreview` builds the upstream URL with `new URL(normalizePreviewPath(path), preview.url)` and attaches the secret `x-v0-preview-token` to that request. The string branch of `normalizePreviewPath` only prepended a slash when the path didn't already start with one:

```typescript
return path.startsWith('/') ? path : `/${path}`
```

A path already starting with `/` was passed through untouched, so a caller-influenced value resolved against `preview.url` as a **protocol- or scheme-relative URL on a different origin**:

- `//attacker.example/steal` → `https://attacker.example/steal`
- `/\attacker.example/steal` (browsers treat `\` as `/`)
- `https://attacker.example/steal`

**Impact (Low):** when the `path` is influenced by untrusted input, the request — **with `x-v0-preview-token` attached** — is sent to the attacker's host, leaking the preview token. Bounded because most integrations pass a fixed/derived path, not raw user input; it requires a deployment that forwards attacker-controlled path segments.

## Solution

Two layers:

1. **Normalize** — strip all leading whitespace, slashes, and backslashes, then prepend exactly one slash, forcing an origin-relative path:

```typescript
return `/${path.replace(/^[\s/\\]+/, '')}`
```

2. **Defense-in-depth assert** — after resolving `upstreamUrl`, throw if it isn't on the preview origin, so the token is never attached to a cross-host request:

```typescript
if (upstreamUrl.origin !== new URL(preview.url).origin) {
  throw new Error('Preview path resolved to a different origin than the preview URL.')
}
```

The array branch was already safe (segments are `encodeURIComponent`-encoded).

**Testing:** new `preview-proxy.test.ts` (bun) covering protocol-relative, backslash, scheme-relative, and array inputs staying on the preview origin, plus normal paths forwarded unchanged; added a `test` script to `package.json`.

## Call Stack

\`\`\`text
fetchPreview({ path, preview })
├─ normalizePreviewPath(path)            ← strips leading [\s/\\], forces single-origin path
├─ new URL(normalized, preview.url)
├─ if (upstreamUrl.origin !== preview origin) throw   ← defense-in-depth
└─ fetch(upstreamUrl, { headers: x-v0-preview-token })
\`\`\`