### PR TITLE
Update API v1 SDK for Vercel Connect setup

### DIFF
--- a/packages/v0-sdk/CHANGELOG.md
+++ b/packages/v0-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v0-sdk
 
+## 0.16.6
+
+### Patch Changes
+
+- Add Vercel Connect task resolution and chat metadata support from the API v1 contract.
+
 ## 0.16.5
 
 ### Patch Changes

--- a/packages/v0-sdk/openapi.json
+++ b/packages/v0-sdk/openapi.json
@@ -442,6 +442,16 @@
                             },
                             "required": ["id", "object", "status", "createdAt"],
                             "additionalProperties": false
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            },
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Arbitrary key-value data associated with this chat."
                           }
                         },
                         "required": [
@@ -453,7 +463,8 @@
                           "favorite",
                           "authorId",
                           "webUrl",
-                          "apiUrl"
+                          "apiUrl",
+                          "metadata"
                         ],
                         "additionalProperties": false,
                         "description": "Summary of a chat, including metadata like privacy, author, latest version, and URLs."
@@ -601,6 +612,27 @@
               "type": "string"
             },
             "description": "Filters chats by the Git branch name. Only returns chats that have an active Git connection with the specified branch as the head."
+          },
+          {
+            "name": "metadata",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filters chats by metadata. Returns chats matching every supplied key-value pair.",
+              "type": "object",
+              "propertyNames": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 40
+              },
+              "additionalProperties": {
+                "type": "string",
+                "maxLength": 500
+              }
+            },
+            "description": "Filters chats by metadata. Returns chats matching every supplied key-value pair.",
+            "style": "deepObject",
+            "explode": true
           }
         ],
         "security": [
@@ -1491,7 +1523,7 @@
     "/chats/{chatId}/fork": {
       "post": {
         "summary": "Fork Chat",
-        "description": "Creates a new chat fork (duplicate) from a specific version within an existing chat. Useful for branching off alternate directions without modifying the original conversation.",
+        "description": "Creates a new chat fork (duplicate) from a specific version within a chat created through Platform API v1. To duplicate chats created in v0 web or Platform API v2, use POST /v2/chats/{chatId}/duplicate.",
         "operationId": "chats.fork",
         "tags": ["chats"],
         "requestBody": {
@@ -3572,6 +3604,18 @@
                         "required": ["type", "permissions"],
                         "additionalProperties": false,
                         "description": "Resolves a permission request task. The agent wants to execute a tool (shell command, script, MCP call) and needs approval. Also used to resolve environment variable prompts."
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["vercel-connect-setup"]
+                          }
+                        },
+                        "required": ["type"],
+                        "additionalProperties": false,
+                        "description": "Resolves a Vercel Connect setup task. The agent asked the user to complete connector setup in a browser (a `configure_vercel_connect` agent action with `status: \"setup-required\"`). Complete setup at the action’s `setupUrl`, poll GET /chats/{chatId}/connect/status until it returns `ready`, then send this task. The server verifies the setup result and attaches the connector; no connector ID is needed. Returns 409 if setup is still pending or failed, or 404 if setup has not started or the request expired."
                       }
                     ],
                     "description": "The task resolution data. Use this when the chat is waiting for user input on the matching task type."
@@ -10364,6 +10408,16 @@
             "required": ["id", "object", "status", "createdAt", "files"],
             "additionalProperties": false
           },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary key-value data associated with this chat."
+          },
           "url": {
             "type": "string",
             "description": "The canonical URL to access this chat.",
@@ -10848,16 +10902,6 @@
             },
             "required": ["write"],
             "additionalProperties": false
-          },
-          "metadata": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "Arbitrary key-value data associated with this chat."
           }
         },
         "required": [
@@ -10870,11 +10914,11 @@
           "authorId",
           "webUrl",
           "apiUrl",
+          "metadata",
           "url",
           "messages",
           "text",
-          "permissions",
-          "metadata"
+          "permissions"
         ],
         "additionalProperties": false,
         "description": "Detailed representation of a chat, including its messages, files, versions, and model configuration."
@@ -10984,6 +11028,16 @@
             },
             "required": ["id", "object", "status", "createdAt"],
             "additionalProperties": false
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary key-value data associated with this chat."
           }
         },
         "required": [
@@ -10995,7 +11049,8 @@
           "favorite",
           "authorId",
           "webUrl",
-          "apiUrl"
+          "apiUrl",
+          "metadata"
         ],
         "additionalProperties": false,
         "description": "Summary of a chat, including metadata like privacy, author, latest version, and URLs."
@@ -13219,6 +13274,16 @@
                   },
                   "required": ["id", "object", "status", "createdAt"],
                   "additionalProperties": false
+                },
+                "metadata": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Arbitrary key-value data associated with this chat."
                 }
               },
               "required": [
@@ -13230,7 +13295,8 @@
                 "favorite",
                 "authorId",
                 "webUrl",
-                "apiUrl"
+                "apiUrl",
+                "metadata"
               ],
               "additionalProperties": false,
               "description": "Summary of a chat, including metadata like privacy, author, latest version, and URLs."

--- a/packages/v0-sdk/package.json
+++ b/packages/v0-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v0-sdk",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "TypeScript SDK for the v0 Platform API",
   "homepage": "https://v0.dev/docs/api",
   "repository": {

--- a/packages/v0-sdk/src/sdk/v0.ts
+++ b/packages/v0-sdk/src/sdk/v0.ts
@@ -34,6 +34,7 @@ export type ChatDetail = {
       locked: boolean
     }[]
   }
+  metadata: Record<string, unknown>
   /** @deprecated */
   url: string
   messages: Array<{
@@ -109,7 +110,6 @@ export type ChatDetail = {
   permissions: {
     write: boolean
   }
-  metadata: Record<string, unknown>
 }
 
 export type ChatSummary = {
@@ -137,6 +137,7 @@ export type ChatSummary = {
     createdAt: string
     updatedAt?: string
   }
+  metadata: Record<string, unknown>
 }
 
 export interface DeploymentDetail {
@@ -550,6 +551,7 @@ export type ProjectDetail = {
       createdAt: string
       updatedAt?: string
     }
+    metadata: Record<string, unknown>
   }>
 }
 
@@ -816,6 +818,7 @@ export type ChatsFindResponse = {
       updatedAt?: string
       darkScreenshotUrl?: string
     }
+    metadata: Record<string, unknown>
   }>
 }
 
@@ -1093,6 +1096,18 @@ export interface ChatsResolveTaskRequest {
         status?: never
         content?: never
         answers?: never
+      }
+    | {
+        type: 'vercel-connect-setup'
+        connectedIntegrationNames?: never
+        connectedMcpPresetNames?: never
+        appliedScripts?: never
+        addedEnvVars?: never
+        status?: never
+        content?: never
+        answers?: never
+        permissions?: never
+        userMessage?: never
       }
   responseMode?: 'sync' | 'async' | 'experimental_stream'
   modelConfiguration?: {
@@ -1671,6 +1686,7 @@ export function createClient(config: V0ClientConfig = {}) {
         isFavorite?: boolean
         vercelProjectId?: string
         branch?: string
+        metadata?: Record<string, unknown>
       }): Promise<ChatsFindResponse> {
         const query = params
           ? (Object.fromEntries(
@@ -1687,6 +1703,7 @@ export function createClient(config: V0ClientConfig = {}) {
                     : undefined,
                 vercelProjectId: params.vercelProjectId,
                 branch: params.branch,
+                metadata: params.metadata,
               }).filter(([_, value]) => value !== undefined),
             ) as Record<string, string>)
           : {}

--- a/packages/v0-sdk/tests/chats/resolve-task.test.ts
+++ b/packages/v0-sdk/tests/chats/resolve-task.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createClient, type ChatsResolveTaskRequest } from '../../src/index'
+import * as core from '../../src/sdk/core'
+
+vi.mock('../../src/sdk/core', () => ({
+  createFetcher: vi.fn(),
+  createStreamingFetcher: vi.fn(() => vi.fn()),
+}))
+
+const mockCreateFetcher = vi.mocked(core.createFetcher)
+const mockFetcher = vi.fn()
+
+describe('v0.chats.resolveTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateFetcher.mockReturnValue(mockFetcher)
+  })
+
+  it('resolves a completed Vercel Connect setup task', async () => {
+    const task: ChatsResolveTaskRequest['task'] = {
+      type: 'vercel-connect-setup',
+    }
+    const mockResponse = { id: 'chat-123' }
+    mockFetcher.mockResolvedValue(mockResponse)
+
+    const v0 = createClient()
+    const result = await v0.chats.resolveTask({
+      chatId: 'chat-123',
+      task,
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith(
+      '/chats/chat-123/tasks/resolve',
+      'POST',
+      {
+        pathParams: { chatId: 'chat-123' },
+        body: {
+          task: { type: 'vercel-connect-setup' },
+          responseMode: undefined,
+          modelConfiguration: undefined,
+        },
+      },
+    )
+    expect(result).toEqual(mockResponse)
+  })
+})


### PR DESCRIPTION
Regenerates the legacy API v1 SDK from the live v1 OpenAPI contract.

- accepts `vercel-connect-setup` in `chats.resolveTask`
- includes current chat metadata contract updates
- adds focused request/type coverage
- bumps only `v0-sdk` to 0.16.6

After merge, the temporary release lane publishes only `v0-sdk@0.16.6` under `beta` via npm trusted publishing. `latest` is verified unchanged.