### PR TITLE
Fix v1 chat metadata filter serialization

### DIFF
--- a/packages/v0-sdk/CHANGELOG.md
+++ b/packages/v0-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v0-sdk
 
+## 0.16.7
+
+### Patch Changes
+
+- Fix metadata filter serialization in `chats.find()`.
+
 ## 0.16.6
 
 ### Patch Changes

--- a/packages/v0-sdk/package.json
+++ b/packages/v0-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v0-sdk",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "TypeScript SDK for the v0 Platform API",
   "homepage": "https://v0.dev/docs/api",
   "repository": {

--- a/packages/v0-sdk/src/scripts/generate.ts
+++ b/packages/v0-sdk/src/scripts/generate.ts
@@ -6,6 +6,7 @@ interface Parameter {
   in: 'path' | 'query' | 'header'
   required?: boolean
   schema: any
+  style?: string
 }
 
 interface RequestBodyProperty {
@@ -432,6 +433,11 @@ function generateParameterInterface(
     // Generate proper TypeScript type from schema
     let tsType = schemaToTypeScript(p.schema, {})
 
+    if (p.style === 'deepObject' && p.schema?.additionalProperties) {
+      const valueType = schemaToTypeScript(p.schema.additionalProperties, {})
+      tsType = `Record<string, ${valueType}>`
+    }
+
     // Convert boolean-like string enums to native boolean
     if (
       p.schema?.enum &&
@@ -506,6 +512,32 @@ function generateReturnType(
   return responseTypeName
 }
 
+function generateQueryParamEntry(parameter: Parameter): string {
+  if (parameter.style === 'deepObject') {
+    return `    ...(params.${parameter.name} !== undefined ? Object.fromEntries(Object.entries(params.${parameter.name}).map(([key, value]) => [\`${parameter.name}[\${key}]\`, value])) : {})`
+  }
+
+  const isBooleanEnum =
+    parameter.schema?.enum &&
+    Array.isArray(parameter.schema.enum) &&
+    parameter.schema.enum.length === 2 &&
+    parameter.schema.enum.includes('true') &&
+    parameter.schema.enum.includes('false')
+
+  if (isBooleanEnum) {
+    return `    ${parameter.name}: params.${parameter.name} !== undefined ? String(params.${parameter.name}) : undefined`
+  }
+
+  if (
+    parameter.schema?.type === 'number' ||
+    parameter.schema?.type === 'integer'
+  ) {
+    return `    ${parameter.name}: params.${parameter.name} !== undefined ? String(params.${parameter.name}) : undefined`
+  }
+
+  return `    ${parameter.name}: params.${parameter.name}`
+}
+
 function generateFunctionBody(
   route: string,
   method: string,
@@ -543,26 +575,7 @@ function generateFunctionBody(
       lines.push(`const query = params ? Object.fromEntries(`)
       lines.push(`  Object.entries({`)
       const queryParamEntries = queryParams
-        .map((p) => {
-          // Convert boolean to string for boolean-like enums
-          const isBooleanEnum =
-            p.schema?.enum &&
-            Array.isArray(p.schema.enum) &&
-            p.schema.enum.length === 2 &&
-            p.schema.enum.includes('true') &&
-            p.schema.enum.includes('false')
-
-          if (isBooleanEnum) {
-            return `    ${p.name}: params.${p.name} !== undefined ? String(params.${p.name}) : undefined`
-          }
-
-          // Convert numbers to strings for query parameters
-          if (p.schema?.type === 'number' || p.schema?.type === 'integer') {
-            return `    ${p.name}: params.${p.name} !== undefined ? String(params.${p.name}) : undefined`
-          }
-
-          return `    ${p.name}: params.${p.name}`
-        })
+        .map(generateQueryParamEntry)
         .join(',\n')
       lines.push(queryParamEntries)
       lines.push(`  }).filter(([_, value]) => value !== undefined)`)
@@ -571,26 +584,7 @@ function generateFunctionBody(
       lines.push(`const query = Object.fromEntries(`)
       lines.push(`  Object.entries({`)
       const queryParamEntries = queryParams
-        .map((p) => {
-          // Convert boolean to string for boolean-like enums
-          const isBooleanEnum =
-            p.schema?.enum &&
-            Array.isArray(p.schema.enum) &&
-            p.schema.enum.length === 2 &&
-            p.schema.enum.includes('true') &&
-            p.schema.enum.includes('false')
-
-          if (isBooleanEnum) {
-            return `    ${p.name}: params.${p.name} !== undefined ? String(params.${p.name}) : undefined`
-          }
-
-          // Convert numbers to strings for query parameters
-          if (p.schema?.type === 'number' || p.schema?.type === 'integer') {
-            return `    ${p.name}: params.${p.name} !== undefined ? String(params.${p.name}) : undefined`
-          }
-
-          return `    ${p.name}: params.${p.name}`
-        })
+        .map(generateQueryParamEntry)
         .join(',\n')
       lines.push(queryParamEntries)
       lines.push(`  }).filter(([_, value]) => value !== undefined)`)

--- a/packages/v0-sdk/src/sdk/v0.ts
+++ b/packages/v0-sdk/src/sdk/v0.ts
@@ -1686,7 +1686,7 @@ export function createClient(config: V0ClientConfig = {}) {
         isFavorite?: boolean
         vercelProjectId?: string
         branch?: string
-        metadata?: Record<string, unknown>
+        metadata?: Record<string, string>
       }): Promise<ChatsFindResponse> {
         const query = params
           ? (Object.fromEntries(
@@ -1703,7 +1703,14 @@ export function createClient(config: V0ClientConfig = {}) {
                     : undefined,
                 vercelProjectId: params.vercelProjectId,
                 branch: params.branch,
-                metadata: params.metadata,
+                ...(params.metadata !== undefined
+                  ? Object.fromEntries(
+                      Object.entries(params.metadata).map(([key, value]) => [
+                        `metadata[${key}]`,
+                        value,
+                      ]),
+                    )
+                  : {}),
               }).filter(([_, value]) => value !== undefined),
             ) as Record<string, string>)
           : {}

--- a/packages/v0-sdk/tests/chats/find.test.ts
+++ b/packages/v0-sdk/tests/chats/find.test.ts
@@ -52,6 +52,26 @@ describe('v0.chats.find', () => {
     expect(result).toEqual(mockResponse)
   })
 
+  it('should serialize metadata using deep-object query parameters', async () => {
+    mockFetcher.mockResolvedValue({ data: [] })
+
+    await v0.chats.find({
+      limit: 20,
+      metadata: {
+        websiteId: 'site_123',
+        environment: 'production',
+      },
+    })
+
+    expect(mockFetcher).toHaveBeenCalledWith('/chats', 'GET', {
+      query: {
+        limit: '20',
+        'metadata[websiteId]': 'site_123',
+        'metadata[environment]': 'production',
+      },
+    })
+  })
+
   it('should handle empty response', async () => {
     const mockResponse = {
       data: [],

--- a/packages/v0-sdk/tests/core.test.ts
+++ b/packages/v0-sdk/tests/core.test.ts
@@ -156,6 +156,29 @@ describe('createFetcher', () => {
       )
     })
 
+    it('should preserve bracketed deep-object query parameters', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+        headers: new Headers(),
+      })
+
+      const fetcher = createFetcher()
+      const query = {
+        'metadata[websiteId]': 'site_123',
+        'metadata[environment]': 'production',
+      }
+
+      await fetcher('/chats', 'GET', { query })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.v0.dev/v1/chats?metadata%5BwebsiteId%5D=site_123&metadata%5Benvironment%5D=production',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      )
+    })
+
     it('should handle path parameters', async () => {
       mockFetch.mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## Summary

- serialize `chats.find({ metadata })` using OpenAPI deep-object query parameters
- generate `Record<string, string>` for the metadata filter
- add generated-client and final-URL regression coverage
- release `v0-sdk@0.16.7` under the `latest` npm tag

## Validation

- `pnpm --filter v0-sdk type-check`
- `pnpm --filter v0-sdk test` (171 tests)
- `pnpm --filter v0-sdk build`
- packed-tarball smoke test asserting `metadata%5BwebsiteId%5D=site_123`
