### PR TITLE
Prepare React usage fixture for model field

### DIFF
--- a/packages/react/tests/helpers.tsx
+++ b/packages/react/tests/helpers.tsx
@@ -28,6 +28,11 @@ export function message(
 ): Message {
   const overrides = typeof value === 'string' ? { id: value, role: 'assistant' as const } : value
   const now = new Date('2026-01-02T03:04:05.000Z')
+  const usage = {
+    model: null,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    creditsCost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
   return {
     chatId: 'chat_1',
     createdAt: now,
@@ -38,10 +43,7 @@ export function message(
     restorable: false,
     finishReason: overrides.role === 'assistant' ? null : 'stop',
     authorId: overrides.role === 'user' ? 'user_1' : null,
-    usage: {
-      tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      creditsCost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

Prepare the React test message fixture for the new `usage.model` response field.

- Keeps the fixture compatible with the currently generated SDK types.
- Allows the autogenerated SDK update in #231 to remain generated-only.

## Problem

Production OpenAPI now defines `usage.model` as required and nullable. The autogenerated SDK update reflects that contract, but the hand-written React test fixture constructs the previous usage shape and fails typechecking. Manual changes on the generated PR branch are not durable because the generation workflow replaces that branch.

## Solution

Hoist the fixture usage value and include `model: null`. Structural assignment permits the forward-compatible field with the current SDK type while satisfying the regenerated type once the OpenAPI update lands.

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run test`
- Repeated build, typecheck, and tests with this commit applied on top of #231
